### PR TITLE
Pointer offset macros

### DIFF
--- a/src/language/bsqtype.h
+++ b/src/language/bsqtype.h
@@ -2,6 +2,7 @@
 
 #include "common.h"
 
+// Make these '0' and '1' and stuff
 #define PTR_MASK_NOP = ((char)0)
 #define PTR_MASK_PTR = ((char)1)
 #define PTR_MASK_TAG = ((char)2)

--- a/src/runtime/memory/allocator.c
+++ b/src/runtime/memory/allocator.c
@@ -7,7 +7,7 @@
 #define CANARY_DEBUG_CHECK
 
 /* Static declarations of our allocator bin and page manager structures */
-AllocatorBin a_bin = {.freelist = NULL, .entrysize = DEFAULT_ENTRY_SIZE, .page = NULL, .page_manager = NULL};
+AllocatorBin a_bin = {.freelist = NULL, .entrysize = sizeof(void*), .page = NULL, .page_manager = NULL};
 PageManager p_mgr = {.all_pages = NULL, .evacuate_page = NULL, .filled_pages = NULL};
 
 static void setup_freelist(PageInfo* pinfo, uint16_t entrysize) {
@@ -86,7 +86,7 @@ AllocatorBin* initializeAllocatorBin(uint16_t entrysize)
     if(bin == NULL) return NULL;
 
     bin->page_manager = &p_mgr;
-    bin->page_manager->evacuate_page = allocateFreshPage(DEFAULT_ENTRY_SIZE);
+    bin->page_manager->evacuate_page = allocateFreshPage(entrysize);
 
     getFreshPageForAllocator(bin);
 

--- a/src/runtime/memory/allocator.h
+++ b/src/runtime/memory/allocator.h
@@ -28,13 +28,14 @@
 #define MEM_STATS_ARG(X)
 #endif
 
-#define SETUP_META_FLAGS(meta)              \
-do {                                        \
+#define SETUP_META_FLAGS(meta)             \
+do {                                       \
     (meta)->isalloc = true;                \
     (meta)->isyoung = true;                \
     (meta)->ismarked = false;              \
     (meta)->isroot = false;                \
     (meta)->forward_index = MAX_FWD_INDEX; \
+    (meta)->ref_count = 0;                 \
 } while(0)
 
 ////////////////////////////////

--- a/src/runtime/memory/gc.c
+++ b/src/runtime/memory/gc.c
@@ -267,9 +267,16 @@ void walk_stack()
     while(cur_stack[i]) {
         void* addr = cur_stack[i];
         if(pagetable_query(addr)) {
-            MetaData* m = NULL;
-            GC_GET_META_DATA_ADDR(addr, m);
-            if(m->isalloc) {
+            if (!(PAGE_IS_OBJ_ALIGNED(addr))) {
+                void* closest_obj_base = PAGE_FIND_OBJ_BASE(addr);
+                /* Maybe put this check to make sure our unaligned pointer is actual in data seg as a macro */
+                if(addr >= closest_obj_base && 
+                    addr < (void*)((char*)closest_obj_base + PAGE_MASK_EXTRACT_PINFO(addr)->entrysize)){
+                        printf("address %p was not aligned but pointed into data seg\n", addr);
+                        addr = PAGE_FIND_OBJ_BASE(addr);
+                }
+            }
+            if(GC_IS_ALLOCATED(addr)) {
                 debug_print("Found a root at %p storing 0x%x\n", addr, *(int*)addr);
             }
         }

--- a/src/runtime/memory/gc.c
+++ b/src/runtime/memory/gc.c
@@ -267,7 +267,9 @@ void walk_stack()
     while(cur_stack[i]) {
         void* addr = cur_stack[i];
         if(pagetable_query(addr)) {
-            if(META_FROM_OBJECT(addr)->isalloc) {
+            MetaData* m = NULL;
+            GC_GET_META_DATA_ADDR(addr, m);
+            if(m->isalloc) {
                 debug_print("Found a root at %p storing 0x%x\n", addr, *(int*)addr);
             }
         }

--- a/src/runtime/memory/gc.h
+++ b/src/runtime/memory/gc.h
@@ -88,18 +88,14 @@ void mark_and_evacuate(AllocatorBin* bin);
 void walk_stack();
 
 /* Incremented in marking */
-static inline void increment_ref_count(Object* obj) {
-    MetaData* m = NULL;
-    GC_GET_META_DATA_ADDR(obj, m);
-    GC_REF_COUNT(m)++;
+static inline void increment_ref_count(void* obj) {
+    GC_REF_COUNT(obj)++;
 }
 
 /* Old location decremented in evacuation */
-static inline void decrement_ref_count(Object* obj) {   
-    MetaData* m = NULL;
-    GC_GET_META_DATA_ADDR(obj, m); 
-    if(GC_REF_COUNT(m) > 0) {
-        GC_REF_COUNT(m)--;
+static inline void decrement_ref_count(void* obj) {   
+    if(GC_REF_COUNT(obj) > 0) {
+        GC_REF_COUNT(obj)--;
     }
 
     // Maybe free object if not root and ref count 0 here?

--- a/src/runtime/memory/gc.h
+++ b/src/runtime/memory/gc.h
@@ -89,13 +89,17 @@ void walk_stack();
 
 /* Incremented in marking */
 static inline void increment_ref_count(Object* obj) {
-    GC_REF_COUNT(obj)++;
+    MetaData* m = NULL;
+    GC_GET_META_DATA_ADDR(obj, m);
+    GC_REF_COUNT(m)++;
 }
 
 /* Old location decremented in evacuation */
-static inline void decrement_ref_count(Object* obj) {    
-    if(GC_REF_COUNT(obj) > 0) {
-        GC_REF_COUNT(obj)--;
+static inline void decrement_ref_count(Object* obj) {   
+    MetaData* m = NULL;
+    GC_GET_META_DATA_ADDR(obj, m); 
+    if(GC_REF_COUNT(m) > 0) {
+        GC_REF_COUNT(m)--;
     }
 
     // Maybe free object if not root and ref count 0 here?

--- a/src/runtime/support/threadinfo.c
+++ b/src/runtime/support/threadinfo.c
@@ -68,11 +68,12 @@ void loadNativeRootSet()
                 debug_print("potential_ptr %p, current_frame %p\n", potential_ptr, current_frame);
                 if (PTR_IN_RANGE(potential_ptr) && PTR_NOT_IN_STACK(native_stack_base, end_of_frame, potential_ptr)) {
                     native_stack_contents[i++] = potential_ptr;
-                    debug_print("current found %i potential pointers\n", i);
+                    debug_print("found potential pointer at %p storint %p\n", it, potential_ptr);
                 }
                 it--;
             }
             /* Move to the next frame */
+            debug_print("currently found %i potential pointers\n", i);
             end_of_frame = current_frame + 2; // update frame boundary to just after return of prev frame
             current_frame = *(void**)current_frame; // Move to the next frame
         }

--- a/test/memory/memex.c
+++ b/test/memory/memex.c
@@ -8,8 +8,7 @@ int main()
     test_stack_walk();
 
     /* Not calling here, appears the compiler is removing some variables that SHOULD be on the stack */
-    walk_stack();
-    walk_stack();
+    //walk_stack();
 
     return 0;
 }

--- a/test/memory/memex.c
+++ b/test/memory/memex.c
@@ -8,7 +8,8 @@ int main()
     test_stack_walk();
 
     /* Not calling here, appears the compiler is removing some variables that SHOULD be on the stack */
-    //walk_stack();
+    walk_stack();
+    walk_stack();
 
     return 0;
 }

--- a/test/stack_test.c
+++ b/test/stack_test.c
@@ -4,27 +4,46 @@ int test_stack_walk() {
     /* We assign these global pointers to hold addreses of stack variables, keeping them alive */
     AllocatorBin* bin = initializeAllocatorBin(sizeof(int*));
 
-    /* I am thinking using out allocate method is better here than malloc since the objects now have metadata */
+    int try_to_make_weird_stack_pointer_offsets = 12;
+    debug_print("%i\n", try_to_make_weird_stack_pointer_offsets);
+
+    /* Allocate 10 local variables using the allocator */
     int* local_0 = allocate(bin, NULL);
     int* local_1 = allocate(bin, NULL);
     int* local_2 = allocate(bin, NULL);
     int* local_3 = allocate(bin, NULL);
     int* local_4 = allocate(bin, NULL);
     int* local_5 = allocate(bin, NULL);
+    int* local_6 = allocate(bin, NULL);
+    int* local_7 = allocate(bin, NULL);
+    int* local_8 = allocate(bin, NULL);
+    int* local_9 = allocate(bin, NULL);
 
+    /* Initialize the local variables with unique values */
     *local_0 = 0xDEADBEF0;
     *local_1 = 0xDEADBEF1;
     *local_2 = 0xDEADBEF2;
     *local_3 = 0xDEADBEF3;
     *local_4 = 0xDEADBEF4;
     *local_5 = 0xDEADBEF5;
+    *local_6 = 0xDEADBEF6;
+    *local_7 = 0xDEADBEF7;
+    *local_8 = 0xDEADBEF8;
+    *local_9 = 0xDEADBEF9;
 
+    /* Print the addresses of the allocated objects */
     printf("allocated object at %p\n", local_0);
     printf("allocated object at %p\n", local_1);
     printf("allocated object at %p\n", local_2);
     printf("allocated object at %p\n", local_3);
     printf("allocated object at %p\n", local_4);
     printf("allocated object at %p\n", local_5);
+    printf("allocated object at %p\n", local_6);
+    printf("allocated object at %p\n", local_7);
+    printf("allocated object at %p\n", local_8);
+    printf("allocated object at %p\n", local_9);
+
+    walk_stack();
 
     return 0;
 }

--- a/test/stack_test.c
+++ b/test/stack_test.c
@@ -2,7 +2,7 @@
 
 int test_stack_walk() {
     /* We assign these global pointers to hold addreses of stack variables, keeping them alive */
-    AllocatorBin* bin = initializeAllocatorBin(sizeof(int));
+    AllocatorBin* bin = initializeAllocatorBin(sizeof(int*));
 
     /* I am thinking using out allocate method is better here than malloc since the objects now have metadata */
     int* local_0 = allocate(bin, NULL);
@@ -25,8 +25,6 @@ int test_stack_walk() {
     printf("allocated object at %p\n", local_3);
     printf("allocated object at %p\n", local_4);
     printf("allocated object at %p\n", local_5);
-
-    walk_stack();
 
     return 0;
 }


### PR DESCRIPTION
- wrote macros to determine if a pointer to an object in our page is aligned, if it is not we update to proper alignment before being able to extract metadata. Used when determining pointers to roots.