### PR TITLE
Bsq types

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,2 @@
-# allocator
+# bsqgc
+WIP Garbage Collector for [Bosque](https://github.com/BosqueLanguage/BosqueCore)

--- a/build/makefile
+++ b/build/makefile
@@ -13,6 +13,8 @@ OUT_OBJ=$(BUILD_DIR)output/obj/
 TEST_DIR=$(MAKE_PATH)/../test/
 MEMORY_TEST_DIR=$(MAKE_PATH)/../test/memory/
 
+LANGUAGE_DIR=$(MAKE_PATH)/../src/language/
+
 #dev is default, for another flavor : make BUILD=release or debug
 BUILD := dev
 
@@ -29,15 +31,19 @@ SUPPORT_HEADERS=$(RUNTIME_DIR)common.h $(SUPPORT_DIR)xalloc.h  $(SUPPORT_DIR)sta
 SUPPORT_SOURCES=$(RUNTIME_DIR)common.c $(SUPPORT_DIR)xalloc.c  $(SUPPORT_DIR)stack.c $(SUPPORT_DIR)arraylist.c $(SUPPORT_DIR)worklist.c $(SUPPORT_DIR)threadinfo.c $(SUPPORT_DIR)pagetable.c
 SUPPORT_OBJS=$(OUT_OBJ)common.o $(OUT_OBJ)xalloc.o $(OUT_OBJ)stack.o $(OUT_OBJ)arraylist.o $(OUT_OBJ)worklist.o $(OUT_OBJ)threadinfo.o $(OUT_OBJ)pagetable.o
 
+LANGUAGE_HEADERS=$(LANGUAGE_DIR)bsqtype.h
+LANGUAGE_SOURCES=$(LANGUAGE_DIR)bsqtype.c
+LANGUAGE_OBJS=$(OUT_OBJ)bsqtype.o
+
 MEMORY_HEADERS=$(RUNTIME_DIR)common.h $(MEMORY_DIR)allocator.h $(TEST_DIR)test.h $(TEST_DIR)stack_test.h $(MEMORY_DIR)gc.h
 MEMORY_SOURCES=$(MEMORY_DIR)allocator.c $(TEST_DIR)test.c $(MEMORY_DIR)gc.c $(TEST_DIR)stack_test.c
 MEMORY_OBJS=$(OUT_OBJ)allocator.o $(OUT_OBJ)test.o $(OUT_OBJ)stack_test.o $(OUT_OBJ)gc.o 
 
 all: $(OUT_EXE)memex
 
-$(OUT_EXE)memex: $(SUPPORT_HEADERS) $(MEMORY_HEADERS) $(SUPPORT_OBJS) $(MEMORY_OBJS) $(MEMORY_TEST_DIR)/memex.c
+$(OUT_EXE)memex: $(SUPPORT_HEADERS) $(LANGUAGE_HEADERS) $(MEMORY_HEADERS) $(SUPPORT_OBJS) $(LANGUAGE_OBJS) $(MEMORY_OBJS) $(MEMORY_TEST_DIR)/memex.c
 	@mkdir -p $(OUT_EXE)
-	$(CC) $(CFLAGS) -o $(OUT_EXE)memex $(SUPPORT_OBJS) $(MEMORY_OBJS) $(MEMORY_TEST_DIR)/memex.c
+	$(CC) $(CFLAGS) -o $(OUT_EXE)memex $(SUPPORT_OBJS) $(LANGUAGE_OBJS) $(MEMORY_OBJS) $(MEMORY_TEST_DIR)/memex.c
 
 $(OUT_OBJ)allocator.o: $(MEMORY_HEADERS) $(MEMORY_DIR)allocator.c
 	@mkdir -p $(OUT_OBJ)
@@ -70,6 +76,10 @@ $(OUT_OBJ)xalloc.o: $(SUPPORT_HEADERS) $(SUPPORT_DIR)xalloc.c
 $(OUT_OBJ)pagetable.o: $(SUPPORT_HEADERS) $(SUPPORT_DIR)pagetable.c
 	@mkdir -p $(OUT_OBJ)
 	$(CC) $(CFLAGS) -o $(OUT_OBJ)pagetable.o -c $(SUPPORT_DIR)pagetable.c
+
+$(OUT_OBJ)bsqtype.o: $(LANGUAGE_HEADERS) $(LANGUAGE_DIR)bsqtype.c
+	@mkdir -p $(OUT_OBJ)
+	$(CC) $(CFLAGS) -o $(OUT_OBJ)bsqtype.o -c $(LANGUAGE_DIR)bsqtype.c
 
 $(OUT_OBJ)common.o: $(SUPPORT_HEADERS) $(RUNTIME_DIR)common.c
 	@mkdir -p $(OUT_OBJ)

--- a/src/language/bsqtype.c
+++ b/src/language/bsqtype.c
@@ -1,0 +1,17 @@
+#include "bsqtype.h"
+
+struct TypeInfoBase Empty = {
+    .type_id = 0,
+    .type_size = 8,
+    .slot_size = 8,
+    .ptr_mask = "0",  
+    .typekey = "Empty"
+};
+
+struct TypeInfoBase ListNode = {
+    .type_id = 1,
+    .type_size = 16,
+    .slot_size = 8,
+    .ptr_mask = "01",  // First slot is not a pointer, second is a pointer
+    .typekey = "ListNode"
+};

--- a/src/language/bsqtype.c
+++ b/src/language/bsqtype.c
@@ -3,7 +3,7 @@
 struct TypeInfoBase Empty = {
     .type_id = 0,
     .type_size = 8,
-    .slot_size = 8,
+    .slot_size = 1,
     .ptr_mask = "0",  
     .typekey = "Empty"
 };
@@ -11,7 +11,7 @@ struct TypeInfoBase Empty = {
 struct TypeInfoBase ListNode = {
     .type_id = 1,
     .type_size = 16,
-    .slot_size = 8,
+    .slot_size = 2,
     .ptr_mask = "01",  // First slot is not a pointer, second is a pointer
     .typekey = "ListNode"
 };

--- a/src/language/bsqtype.h
+++ b/src/language/bsqtype.h
@@ -2,9 +2,9 @@
 
 #include "common.h"
 
-#define PTR_MASK_NOP = ((char)0)
-#define PTR_MASK_PTR = ((char)1)
-#define PTR_MASK_TAG = ((char)2)
+#define PTR_MASK_NOP  ('0')
+#define PTR_MASK_PTR  ('1')
+#define PTR_MASK_TAG  ('2')
 
 #define LEAF_PTR_MASK = NULL
 

--- a/src/language/bsqtype.h
+++ b/src/language/bsqtype.h
@@ -2,7 +2,6 @@
 
 #include "common.h"
 
-// Make these '0' and '1' and stuff
 #define PTR_MASK_NOP = ((char)0)
 #define PTR_MASK_PTR = ((char)1)
 #define PTR_MASK_TAG = ((char)2)
@@ -12,7 +11,12 @@
 struct TypeInfoBase {
     uint32_t type_id;
     uint32_t type_size;
+    uint32_t slot_size;
     const char* ptr_mask; //NULL is for leaf values or structs
 
     const char* typekey;
 };
+
+extern struct TypeInfoBase Empty;
+extern struct TypeInfoBase ListNode;
+

--- a/src/language/bsqtype.h
+++ b/src/language/bsqtype.h
@@ -6,7 +6,7 @@
 #define PTR_MASK_PTR  ('1')
 #define PTR_MASK_TAG  ('2')
 
-#define LEAF_PTR_MASK = NULL
+#define LEAF_PTR_MASK  NULL
 
 struct TypeInfoBase {
     uint32_t type_id;

--- a/src/runtime/common.h
+++ b/src/runtime/common.h
@@ -110,6 +110,9 @@ extern size_t tl_id_counter;
 
 #endif
 
+/* Used to determine if a pointer points into the data segment of an object */
+#define POINTS_TO_DATA_SEG(P) P >= (void*)PAGE_FIND_OBJ_BASE(P) && P < (void*)((char*)PAGE_FIND_OBJ_BASE(P) + PAGE_MASK_EXTRACT_PINFO(P)->entrysize)
+
 // Allows us to correctly determine pointer offsets
 #ifdef ALLOC_DEBUG_CANARY
 #define REAL_ENTRY_SIZE(ESIZE) (ALLOC_DEBUG_CANARY_SIZE + ESIZE + sizeof(MetaData) + ALLOC_DEBUG_CANARY_SIZE)
@@ -158,6 +161,7 @@ do {                                                 \
 #define GC_IS_ROOT(O) (GC_GET_META_DATA_ADDR(O))->isroot
 #define GC_FWD_INDEX(O) (GC_GET_META_DATA_ADDR(O))->forward_index
 #define GC_REF_COUNT(O) (GC_GET_META_DATA_ADDR(O))->ref_count
+#define GC_TYPE(O) (GC_GET_META_DATA_ADDR(O))->type
 
 #else
 

--- a/src/runtime/common.h
+++ b/src/runtime/common.h
@@ -9,6 +9,8 @@
 #include <threads.h>
 #include <sys/mman.h> //mmap
 
+#include "../language/bsqtype.h"
+
 //DEFAULT ENABLED WHILE LOTS OF DEVELOPMENT!!!!
 #define BSQ_GC_CHECK_ENABLED
 #define MEM_STATS
@@ -126,6 +128,7 @@ typedef struct MetaData
     bool isroot;
     uint32_t forward_index;
     uint32_t ref_count;
+    struct TypeInfoBase* type;
 } MetaData; 
 #else
 typedef struct MetaData 

--- a/src/runtime/memory/allocator.c
+++ b/src/runtime/memory/allocator.c
@@ -7,7 +7,9 @@
 #define CANARY_DEBUG_CHECK
 
 /* Static declarations of our allocator bin and page manager structures */
-AllocatorBin a_bin = {.freelist = NULL, .entrysize = sizeof(void*), .page = NULL, .page_manager = NULL};
+AllocatorBin a_bin8 = {.freelist = NULL, .entrysize = 8, .page = NULL, .page_manager = NULL};
+AllocatorBin a_bin16 = {.freelist = NULL, .entrysize = 16, .page = NULL, .page_manager = NULL};
+
 PageManager p_mgr = {.all_pages = NULL, .evacuate_page = NULL, .filled_pages = NULL};
 
 static void setup_freelist(PageInfo* pinfo, uint16_t entrysize) {
@@ -82,7 +84,15 @@ void getFreshPageForAllocator(AllocatorBin* alloc)
 
 AllocatorBin* initializeAllocatorBin(uint16_t entrysize)
 {
-    AllocatorBin* bin = &a_bin;
+    /* Not too sure about using entry size to determine what bin to use here */
+    AllocatorBin* bin = NULL;
+    if(entrysize == 8) {
+        bin = &a_bin8;
+    }else if (entrysize == 16) {
+        bin = &a_bin16;
+    }
+    assert(bin != NULL);
+
     if(bin == NULL) return NULL;
 
     bin->page_manager = &p_mgr;

--- a/src/runtime/memory/allocator.h
+++ b/src/runtime/memory/allocator.h
@@ -28,14 +28,15 @@
 #define MEM_STATS_ARG(X)
 #endif
 
-#define SETUP_META_FLAGS(meta)             \
-do {                                       \
-    (meta)->isalloc = true;                \
-    (meta)->isyoung = true;                \
-    (meta)->ismarked = false;              \
-    (meta)->isroot = false;                \
-    (meta)->forward_index = MAX_FWD_INDEX; \
-    (meta)->ref_count = 0;                 \
+#define SETUP_META_FLAGS(M, T)          \
+do {                                    \
+    (M)->isalloc = true;                \
+    (M)->isyoung = true;                \
+    (M)->ismarked = false;              \
+    (M)->isroot = false;                \
+    (M)->forward_index = MAX_FWD_INDEX; \
+    (M)->ref_count = 0;                 \
+    (M)->type = T;                      \
 } while(0)
 
 ////////////////////////////////
@@ -82,7 +83,8 @@ typedef struct AllocatorBin
     PageInfo* page;
     PageManager* page_manager;
 } AllocatorBin;
-extern AllocatorBin a_bin;
+extern AllocatorBin a_bin8;
+extern AllocatorBin a_bin16;
 
 /**
  * When needed, get a fresh page from mmap to allocate from 
@@ -108,27 +110,21 @@ PageInfo* allocateFreshPage(uint16_t entrysize);
 /**
  * Slow path for usage with canaries --- debug
  **/
-static inline void* setupSlowPath(FreeListEntry* ret, AllocatorBin* alloc, MetaData** meta){
+static inline void* setupSlowPath(FreeListEntry* ret, AllocatorBin* alloc){
     uint64_t* pre = (uint64_t*)ret;
     *pre = ALLOC_DEBUG_CANARY_VALUE;
 
     uint64_t* post = (uint64_t*)((char*)ret + ALLOC_DEBUG_CANARY_SIZE + sizeof(MetaData) + alloc->entrysize);
     *post = ALLOC_DEBUG_CANARY_VALUE;
 
-    *meta = (MetaData*)((char*)ret + ALLOC_DEBUG_CANARY_SIZE);
-
     return (void*)((uint8_t*)ret + ALLOC_DEBUG_CANARY_SIZE + sizeof(MetaData));
 }
 
 /**
- * Allocate a block of memory of size `size` from the given page. If preserve_meta is true 
- * we are using allocate for moving object to new pages.
+ * Allocate a block of memory of size `size` from the given page.
  **/
-static inline void* allocate(AllocatorBin* alloc, MetaData* metadata)
+static inline void* allocate(AllocatorBin* alloc, struct TypeInfoBase* type)
 {
-    /* If meta is not null we do not want to overwrite any data in it */
-    bool preserve_meta = (metadata != NULL);
-
     if(alloc->freelist == NULL) {
         getFreshPageForAllocator(alloc);
     }
@@ -136,23 +132,14 @@ static inline void* allocate(AllocatorBin* alloc, MetaData* metadata)
     FreeListEntry* ret = alloc->freelist;
     alloc->freelist = ret->next;
 
-    void* obj;
-
     #ifndef ALLOC_DEBUG_CANARY
-    if(!preserve_meta) *metadata = (MetaData*)ret;
-    obj = (void*)((uint8_t*)ret + sizeof(MetaData));
+    void* obj = (void*)((uint8_t*)ret + sizeof(MetaData));
     #else
-    if (preserve_meta) {
-        obj = (void*)((uint8_t*)ret + ALLOC_DEBUG_CANARY_SIZE + sizeof(MetaData));
-    } else {
-        obj = setupSlowPath(ret, alloc, &metadata);
-    }    
+    void* obj = setupSlowPath(ret, alloc);
     #endif
 
-    // If meta was created initialize object
-    if(!preserve_meta) {
-        SETUP_META_FLAGS(metadata);
-    }
+    MetaData* mdata = (MetaData*)((char*)obj - sizeof(MetaData));
+    SETUP_META_FLAGS(mdata, type);
 
     return (void*)obj;
 }

--- a/src/runtime/memory/gc.c
+++ b/src/runtime/memory/gc.c
@@ -225,9 +225,15 @@ void walk_stack(struct Stack* marked_nodes, struct WorkList* worklist)
             }
 
             /* Actual marking logic */
-            if(GC_IS_ALLOCATED(addr) && canupdate) {
+            if(GC_IS_ALLOCATED(addr) && (GC_TYPE(addr)->ptr_mask != LEAF_PTR_MASK) && canupdate) {
                 if(GC_REF_COUNT(addr) > 0) continue;
 
+                if(GC_IS_YOUNG(addr)) {
+                    /* Need some way to handle old roots */
+                    continue;
+                }
+
+                /* If we have a potential pointer with no references and its not marked, set mark bit and set as root */
                 if (GC_REF_COUNT(addr) == 0 && !GC_IS_MARKED(addr)) {
                     GC_IS_MARKED(addr) = true;
                     GC_IS_ROOT(addr) = true;
@@ -283,7 +289,7 @@ void mark_and_evacuate()
                 // Nothing to do, not a pointer
             } 
             else if (mask == PTR_MASK_PTR) {
-                void* child = *(void**)((char*)parent_ptr + i * sizeof(void*));
+                void* child = *(void**)((char*)parent_ptr + i * sizeof(void*)); //hmmm...
                 debug_print("pointer slot points to %p\n", child);
 
                 /* Valid child pointer, so mark and increment ref count then push to mark stack. Explore its pointers */
@@ -307,5 +313,5 @@ void mark_and_evacuate()
     }
     #endif
 
-    // evacuate(&marked_nodes_stack, bin);
+    //evacuate(&marked_nodes, bin);
 }

--- a/src/runtime/memory/gc.c
+++ b/src/runtime/memory/gc.c
@@ -199,65 +199,10 @@ void clean_nonref_nodes(AllocatorBin* bin) {
         current_page = current_page->next;
     }
 } 
-
-/* Algorithm 2.2 from The Gargage Collection Handbook */
-void mark_and_evacuate(AllocatorBin* bin)
-{
-    struct Stack marked_nodes_stack, old_roots_stack;
-    ArrayList worklist;
-
-    initialize_list(&worklist);
-
-    /* We need to be parsing execuation stack for roots here */
-    for (uint16_t i = root_list.head; i < root_list.tail; i++) {
-        Object* root = root_list.data[i];
-
-        /* We want to skip objects with ref count > 0 */
-        if(GC_REF_COUNT(root) > 0) continue;
-
-        else if(GC_IS_YOUNG(root) == false) {
-            /* We will need some way to handle these old roots */
-            stack_push(Object*, &old_roots_stack, root);
-            continue;
-        }
-
-        /* If an object is old we should not mark children */
-        if (GC_REF_COUNT(root) == 0 && GC_IS_MARKED(root) == false) {
-            GC_IS_MARKED(root) = true;
-            add_to_list(&worklist, root);
-        }
-    }
-
-    /* Process the worklist in a BFS manner */
-    while (!is_list_empty(&worklist)) {
-        Object* parent = remove_head_from_list(&worklist);
-
-        for (size_t i = 0; i < parent->num_children; i++) {
-            Object* child = parent->children[i];
-
-            /* We increment the childs ref count since the parent points to it */
-            increment_ref_count(child);
-
-            if (child != NULL) {
-                /* We should only process young objects */
-                if (GC_IS_MARKED(child) == false && GC_IS_YOUNG(child) == true) 
-                {
-                    GC_IS_MARKED(child) = true;
-                    add_to_list(&worklist, child);
-                }
-            }
-        }
-        /* We finished processing this node, add to mark list */
-        stack_push(Object*, &marked_nodes_stack,  parent);
-    }
-
-    // evacuate(&marked_nodes_stack, bin);
-}
-
 #endif
 
 /* This will be integrated into our mark from roots method, for now just walks stack of program */
-void walk_stack() 
+void walk_stack(struct Stack* marked_nodes, struct WorkList* worklist) 
 {
     loadNativeRootSet();
 
@@ -269,19 +214,25 @@ void walk_stack()
         void* addr = cur_stack[i];
         if(pagetable_query(addr)) {
             if (!(PAGE_IS_OBJ_ALIGNED(addr))) {
-                void* closest_obj_base = PAGE_FIND_OBJ_BASE(addr);
-
-                /* check to make sure our pointer was to the actual data of an object, not canary or meta */
-                if(addr >= closest_obj_base && 
-                    addr < (void*)((char*)closest_obj_base + PAGE_MASK_EXTRACT_PINFO(addr)->entrysize)){
-                        printf("address %p was not aligned but pointed into data seg\n", addr);
-                        addr = PAGE_FIND_OBJ_BASE(addr);
-                        canupdate = true;
+                if(POINTS_TO_DATA_SEG(addr)){
+                    debug_print("address %p was not aligned but pointed into data seg\n", addr);
+                    addr = PAGE_FIND_OBJ_BASE(addr);
+                    canupdate = true;
                 } else {
+                    debug_print("found pointer into alloc page that did not point into data seg at %p\n", addr);
                     canupdate = false;
                 }
             }
+
+            /* Actual marking logic */
             if(GC_IS_ALLOCATED(addr) && canupdate) {
+                if(GC_REF_COUNT(addr) > 0) continue;
+
+                if (GC_REF_COUNT(addr) == 0 && GC_IS_MARKED(addr) == false) {
+                    GC_IS_MARKED(addr) = true;
+                    worklist_push(*worklist, addr);
+                }
+
                 debug_print("Found a root at %p storing 0x%x\n", addr, *(int*)addr);
             }
         }
@@ -289,6 +240,7 @@ void walk_stack()
         i++;
     }
 
+    /* This will need to actually modify our marked nodes stack */
     pagetable_query(native_register_contents.rax);
     pagetable_query(native_register_contents.rbx);
     pagetable_query(native_register_contents.rcx);
@@ -305,4 +257,45 @@ void walk_stack()
     pagetable_query(native_register_contents.r15);
 
     unloadNativeRootSet();
+}
+
+/* Algorithm 2.2 from The Gargage Collection Handbook */
+void mark_and_evacuate()
+{
+    struct Stack marked_nodes;
+    struct WorkList worklist;
+
+    worklist_initialize(&worklist);
+
+    walk_stack(&marked_nodes, &worklist);
+
+    /* Process the worklist in a BFS manner */
+    while (!worklist_is_empty(&worklist)) {
+        void* parent_ptr = worklist_pop(void, worklist);
+        struct TypeInfoBase* parent_type = GC_TYPE( parent_ptr );
+        debug_print("parent pointer at %p\n", parent_ptr);
+        
+        for (size_t i = 0; i < parent_type->slot_size; i++) {
+            char mask = *(parent_type->ptr_mask) + i;
+
+            if(mask == PTR_MASK_NOP) {
+                // Nothing to do, not a pointer
+            } else if (mask == PTR_MASK_PTR) {
+                void* child = *(void**)((char*)parent_ptr + i * sizeof(void*));
+                debug_print("parent points to %p\n", child);
+
+                if(child != NULL) {
+                    increment_ref_count(child);
+                    worklist_push(worklist, child);
+                }
+            } else {
+                // Do nothing
+            }
+        }
+
+        /* We finished processing this node, add to mark stack */
+        stack_push(void*, marked_nodes, parent_ptr);
+    }
+
+    // evacuate(&marked_nodes_stack, bin);
 }

--- a/src/runtime/memory/gc.h
+++ b/src/runtime/memory/gc.h
@@ -82,10 +82,10 @@ void clean_nonref_nodes(AllocatorBin* bin);
 /**
  * Process all objects starting from roots in BFS manner
  **/
-void mark_and_evacuate(AllocatorBin* bin);
+void mark_and_evacuate();
 
 /* Testing */
-void walk_stack();
+void walk_stack(struct Stack* marked_nodes, struct WorkList* worklist);
 
 /* Incremented in marking */
 static inline void increment_ref_count(void* obj) {

--- a/src/runtime/support/worklist.c
+++ b/src/runtime/support/worklist.c
@@ -56,3 +56,7 @@ void* worklist_pop_slow(struct WorkList* l) {
 
     return res;
 }
+
+bool worklist_is_empty(struct WorkList* l) {
+    return l->head == NULL || l->tail == NULL;
+}

--- a/src/runtime/support/worklist.h
+++ b/src/runtime/support/worklist.h
@@ -21,8 +21,9 @@ struct WorkList {
 };
 
 #define worklist_push(L, O) if((L).tail && (L).tail < GET_MAX_FOR_SEGMENT((L).tail, WL_SEG_SIZE)) { *(++(L).tail) = O; } else { worklist_push_slow(&(L), O);}
-#define worklist_pop(T, L) ((T*)((L).head != GET_MAX_FOR_SEGMENT((L).head, WL_SEG_SIZE) ? *((L).head++) : worklist_pop_slow(&(L))))
+#define worklist_pop(T, L) ((T*)((L).head != (L).tail ? *((L).head++) : worklist_pop_slow(&(L))))
 
 void worklist_initialize(struct WorkList* l);
 void worklist_push_slow(struct WorkList* l, void* obj);
 void* worklist_pop_slow(struct WorkList* l);
+bool worklist_is_empty(struct WorkList* l);

--- a/test/memory/memex.c
+++ b/test/memory/memex.c
@@ -8,7 +8,7 @@ int main()
     test_stack_walk();
 
     /* Not calling here, appears the compiler is removing some variables that SHOULD be on the stack */
-    //walk_stack();
+    walk_stack();
 
     return 0;
 }

--- a/test/memory/memex.c
+++ b/test/memory/memex.c
@@ -7,8 +7,7 @@ int main()
 
     test_stack_walk();
 
-    /* Not calling here, appears the compiler is removing some variables that SHOULD be on the stack */
-    walk_stack();
-
+    mark_and_evacuate();
+    
     return 0;
 }

--- a/test/stack_test.c
+++ b/test/stack_test.c
@@ -15,7 +15,7 @@ int test_stack_walk() {
     *((int64_t*)ln) = 0xDEADBEF0;
 
     /* data ln points to stores some stuff */
-    *(int64_t*)e = 0xDEADBEF1;
+    *((int64_t*)e) = 0xDEADBEF1;
 
     /* Second slot of ln stores a pointer to e */
     void** second_slot = (void**)((int64_t*)ln + 1);

--- a/test/stack_test.c
+++ b/test/stack_test.c
@@ -2,48 +2,27 @@
 
 int test_stack_walk() {
     /* We assign these global pointers to hold addreses of stack variables, keeping them alive */
-    AllocatorBin* bin = initializeAllocatorBin(sizeof(int*));
+    AllocatorBin* bin16 = initializeAllocatorBin(ListNode.type_size);
+    AllocatorBin* bin8 = initializeAllocatorBin(Empty.type_size);
 
-    int try_to_make_weird_stack_pointer_offsets = 12;
+    char try_to_make_weird_stack_pointer_offsets = 'a';
     debug_print("%i\n", try_to_make_weird_stack_pointer_offsets);
 
-    /* Allocate 10 local variables using the allocator */
-    int* local_0 = allocate(bin, NULL);
-    int* local_1 = allocate(bin, NULL);
-    int* local_2 = allocate(bin, NULL);
-    int* local_3 = allocate(bin, NULL);
-    int* local_4 = allocate(bin, NULL);
-    int* local_5 = allocate(bin, NULL);
-    int* local_6 = allocate(bin, NULL);
-    int* local_7 = allocate(bin, NULL);
-    int* local_8 = allocate(bin, NULL);
-    int* local_9 = allocate(bin, NULL);
+    void* e = allocate(bin8, &Empty);
+    void* ln = allocate(bin16, &ListNode);
 
-    /* Initialize the local variables with unique values */
-    *local_0 = 0xDEADBEF0;
-    *local_1 = 0xDEADBEF1;
-    *local_2 = 0xDEADBEF2;
-    *local_3 = 0xDEADBEF3;
-    *local_4 = 0xDEADBEF4;
-    *local_5 = 0xDEADBEF5;
-    *local_6 = 0xDEADBEF6;
-    *local_7 = 0xDEADBEF7;
-    *local_8 = 0xDEADBEF8;
-    *local_9 = 0xDEADBEF9;
+    /* First slot of ln stores some data */
+    *((int64_t*)ln) = 0xDEADBEF0;
 
-    /* Print the addresses of the allocated objects */
-    printf("allocated object at %p\n", local_0);
-    printf("allocated object at %p\n", local_1);
-    printf("allocated object at %p\n", local_2);
-    printf("allocated object at %p\n", local_3);
-    printf("allocated object at %p\n", local_4);
-    printf("allocated object at %p\n", local_5);
-    printf("allocated object at %p\n", local_6);
-    printf("allocated object at %p\n", local_7);
-    printf("allocated object at %p\n", local_8);
-    printf("allocated object at %p\n", local_9);
+    /* data ln points to stores some stuff */
+    *(int64_t*)e = 0xDEADBEF1;
 
-    walk_stack();
+    /* Second slot of ln stores a pointer to e */
+    void** second_slot = (void**)((int64_t*)ln + 1);
+    *second_slot = e;
+
+    debug_print("First slot of ln: 0x%lx\n", *((int64_t*)ln));
+    debug_print("Second slot of ln: %p (should be equal to e: %p)\n", *second_slot, e);
 
     return 0;
 }

--- a/test/stack_test.c
+++ b/test/stack_test.c
@@ -8,21 +8,54 @@ int test_stack_walk() {
     char try_to_make_weird_stack_pointer_offsets = 'a';
     debug_print("%i\n", try_to_make_weird_stack_pointer_offsets);
 
-    void* e = allocate(bin8, &Empty);
-    void* ln = allocate(bin16, &ListNode);
+    /* Create the end node (not part of the linked list, but pointed to by the last node) */
+    void* end = allocate(bin8, &Empty);
+    *((int64_t*)end) = 0xDEADBEF4; // Store some data in the end node
 
-    /* First slot of ln stores some data */
-    *((int64_t*)ln) = 0xDEADBEF0;
+    /* Create the linked list nodes */
+    void* ln0 = allocate(bin16, &ListNode);
+    void* ln1 = allocate(bin16, &ListNode);
+    void* ln2 = allocate(bin16, &ListNode);
+    void* ln3 = allocate(bin16, &ListNode);
 
-    /* data ln points to stores some stuff */
-    *((int64_t*)e) = 0xDEADBEF1;
+    /* Store data in the first slot of each ListNode */
+    *((int64_t*)ln0) = 0xDEADBEF0;
+    *((int64_t*)ln1) = 0xDEADBEF1;
+    *((int64_t*)ln2) = 0xDEADBEF2;
+    *((int64_t*)ln3) = 0xDEADBEF3;
 
-    /* Second slot of ln stores a pointer to e */
-    void** second_slot = (void**)((int64_t*)ln + 1);
-    *second_slot = e;
+    /* Link the nodes together */
+    void** second_slot0 = (void**)((int64_t*)ln0 + 1);
+    *second_slot0 = ln1; // ln0 points to ln1
 
-    debug_print("First slot of ln: 0x%lx\n", *((int64_t*)ln));
-    debug_print("Second slot of ln: %p (should be equal to e: %p)\n", *second_slot, e);
+    void** second_slot1 = (void**)((int64_t*)ln1 + 1);
+    *second_slot1 = ln2; // ln1 points to ln2
+
+    void** second_slot2 = (void**)((int64_t*)ln2 + 1);
+    *second_slot2 = ln3; // ln2 points to ln3
+
+    void** second_slot3 = (void**)((int64_t*)ln3 + 1);
+    *second_slot3 = end; // ln3 points to end
+
+    /* Debug prints to verify the structure */
+    debug_print("Root node (ln0) at %p:\n", ln0);
+    debug_print("  First slot: 0x%lx\n", *((int64_t*)ln0));
+    debug_print("  Second slot: %p (points to ln1)\n", *second_slot0);
+
+    debug_print("Node ln1 at %p:\n", ln1);
+    debug_print("  First slot: 0x%lx\n", *((int64_t*)ln1));
+    debug_print("  Second slot: %p (points to ln2)\n", *second_slot1);
+
+    debug_print("Node ln2 at %p:\n", ln2);
+    debug_print("  First slot: 0x%lx\n", *((int64_t*)ln2));
+    debug_print("  Second slot: %p (points to ln3)\n", *second_slot2);
+
+    debug_print("Node ln3 at %p:\n", ln3);
+    debug_print("  First slot: 0x%lx\n", *((int64_t*)ln3));
+    debug_print("  Second slot: %p (points to end)\n", *second_slot3);
+
+    debug_print("End node at %p:\n", end);
+    debug_print("  First slot: 0x%lx\n", *((int64_t*)end));
 
     return 0;
 }


### PR DESCRIPTION
- added ListNode and Empty which all derive from TypeInfoBase so we can start actually doing some gc stuff
- allocate() now takes in the specific bin (bin8 or bin16 as of now) and takes a type that gets assigned in metadata to be fetched with a macro whenever needed. The type passed in is just one of the two generic types ListNode and Empty for now
- converted old marking code to use new data structures and handle pointer masks for ptr_mask field to properly determine what an object points to

Next is to get evacuation working with these new types