### PR TITLE
Evacuation reworking

### DIFF
--- a/src/runtime/common.h
+++ b/src/runtime/common.h
@@ -94,7 +94,7 @@ extern size_t tl_id_counter;
 
 
 #define FREE_LIST_ENTRY_AT(page, index) \
-((FreeListEntry*)(PAGE_OFFSET(page) + (index) * REAL_ENTRY_SIZE((page)->entrysize)))
+((FreeListEntry*)(PAGE_MASK_EXTRACT_DATA(page) + (index) * REAL_ENTRY_SIZE((page)->entrysize)))
 
 #ifdef ALLOC_DEBUG_CANARY
 //Gives us the beginning of block (just before canary in case of canaries enabled)

--- a/src/runtime/common.h
+++ b/src/runtime/common.h
@@ -98,13 +98,13 @@ extern size_t tl_id_counter;
 
 #ifdef ALLOC_DEBUG_CANARY
 //Gives us the beginning of block (just before canary in case of canaries enabled)
-#define BLOCK_START_FROM_OBJ(obj) ((char*)obj - sizeof(MetaData) - ALLOC_DEBUG_CANARY_SIZE)
+#define BLOCK_START_FROM_PTR(obj) ((char*)obj - sizeof(MetaData) - ALLOC_DEBUG_CANARY_SIZE)
 
 //Start of our object from the begginning of block (address returned from allocate())
 #define OBJ_START_FROM_BLOCK(obj) ((char*)obj + sizeof(MetaData) + ALLOC_DEBUG_CANARY_SIZE)
 #define META_FROM_FREELIST_ENTRY(f_entry) ((MetaData*)((char*)f_entry + ALLOC_DEBUG_CANARY_SIZE))
 #else
-#define BLOCK_START_FROM_OBJ(obj) ((char*)obj - sizeof(MetaData))
+#define BLOCK_START_FROM_PTR(obj) ((char*)obj - sizeof(MetaData))
 #define OBJ_START_FROM_BLOCK(obj) ((char*)obj + sizeof(MetaData))
 #define META_FROM_FREELIST_ENTRY(f_entry) ((MetaData*)f_entry)
 

--- a/src/runtime/memory/allocator.c
+++ b/src/runtime/memory/allocator.c
@@ -10,7 +10,9 @@
 AllocatorBin a_bin8 = {.freelist = NULL, .entrysize = 8, .page = NULL, .page_manager = NULL};
 AllocatorBin a_bin16 = {.freelist = NULL, .entrysize = 16, .page = NULL, .page_manager = NULL};
 
-PageManager p_mgr = {.all_pages = NULL, .evacuate_page = NULL, .filled_pages = NULL};
+/* Each AllocatorBin needs its own page manager */
+PageManager p_mgr8 = {.all_pages = NULL, .evacuate_page = NULL, .filled_pages = NULL};
+PageManager p_mgr16 = {.all_pages = NULL, .evacuate_page = NULL, .filled_pages = NULL};
 
 static void setup_freelist(PageInfo* pinfo, uint16_t entrysize) {
     FreeListEntry* current = pinfo->freelist;
@@ -88,17 +90,29 @@ AllocatorBin* initializeAllocatorBin(uint16_t entrysize)
     AllocatorBin* bin = NULL;
     if(entrysize == 8) {
         bin = &a_bin8;
+        bin->page_manager = &p_mgr8;
     }else if (entrysize == 16) {
         bin = &a_bin16;
+        bin->page_manager = &p_mgr16;
     }
     assert(bin != NULL);
 
     if(bin == NULL) return NULL;
 
-    bin->page_manager = &p_mgr;
     bin->page_manager->evacuate_page = allocateFreshPage(entrysize);
 
     getFreshPageForAllocator(bin);
 
     return bin;
+}
+
+AllocatorBin* getBinForSize(uint16_t entrytsize)
+{
+    switch(entrytsize){
+        case 8: return &a_bin8;
+        case 16: return &a_bin16;
+        default: return NULL;
+    }
+
+    return NULL;
 }

--- a/src/runtime/memory/allocator.h
+++ b/src/runtime/memory/allocator.h
@@ -97,6 +97,12 @@ void getFreshPageForAllocator(AllocatorBin* alloc);
 AllocatorBin* initializeAllocatorBin(uint16_t entrysize);
 
 /**
+* Since our bins can vary in size (always multiple of 8 bytes) depending on the type they hold
+* we need to be able to "dynamically" determine what bin is appropriate given an objects size.
+**/
+AllocatorBin* getBinForSize(uint16_t entrytsize);
+
+/**
  * Setup pointers for managing our pages 
  * we have a list of all pages and those that have stuff in them
  **/

--- a/src/runtime/memory/gc.c
+++ b/src/runtime/memory/gc.c
@@ -1,29 +1,9 @@
 #include "gc.h"
+#include "allocator.h"
 
-#if 0
-
-struct ArrayList f_table;
-struct ArrayList root_list;
-struct ArrayList prev_roots_set;
-
-void collect(AllocatorBin* bin) {
-    mark_and_evacuate(bin);
-    //clean_nonref_nodes(bin);
-
-    /** 
-    * Possibly move clean_nonref_nodes logic out to where we can easily differentiate between our
-    * young and old sets of objects. That way we arent ref counting young objects (and freeing them)
-    * or evacuating old objects (allthough this should not be possible).
-    **/
-}
-
-bool isRoot(void* obj) 
+void collect() 
 {
-    /** 
-    * TODO: Actually implement logic for determining whether a pointer is root,
-    * this would be logic that comes into play AFTER we implement type systems.
-    **/
-    return true; // For now, assume all objects are valid pointers
+    mark_and_evacuate();
 }
 
 static void update_evacuation_freelist(AllocatorBin *bin) {
@@ -34,174 +14,58 @@ static void update_evacuation_freelist(AllocatorBin *bin) {
     }
 }
 
-// Move object to evacuate_page and reset old metadata
-static void* evacuate_object(AllocatorBin *bin, Object* obj, ArrayList* forward_table, struct Stack* pending_resets) {
-    // No need to evacuate old objects
-    if(GC_IS_YOUNG(obj) == false) return NULL;
-    if(META_FROM_OBJECT(obj)->forward_index != MAX_FWD_INDEX) return obj;
+#ifdef ALLOC_DEBUG_CANARY
+static void set_canaries(void* base, size_t entry_size) {
+    // Set pre-canary
+    uint64_t* pre = (uint64_t*)base;
+    *pre = ALLOC_DEBUG_CANARY_VALUE;
 
-    // Insertion into forward table delayed until post evacuation 
-    META_FROM_OBJECT(obj)->forward_index = forward_table->size;
-
-    // Now we proceed with evacuation of young objects
-    FreeListEntry* start_of_evac = bin->page_manager->evacuate_page->freelist;
-    FreeListEntry* next_evac_freelist_object = start_of_evac->next;
-
-    // Direct copy of data from original page to evacuation page
-    void* evac_obj_base = memcpy(start_of_evac, BLOCK_START_FROM_OBJ(obj), REAL_ENTRY_SIZE(DEFAULT_ENTRY_SIZE));
-
-    //update freelist of evac page, memcpy was destroying pointers in our freelist for evac page so I had to manually store and assign after memcpy
-    bin->page_manager->evacuate_page->freelist = next_evac_freelist_object;
-    update_evacuation_freelist(bin);
-
-    debug_print("[DEBUG] Object moved from %p to %p in evac page\n", obj, evac_obj_base);
-
-    // Now that our object has been moved, we update our forward table with ptr to its new data
-    Object* evac_obj_data = (Object*)(OBJ_START_FROM_BLOCK(evac_obj_base));
-    add_to_list(forward_table, evac_obj_data);
-    
-    // Insert evacuated object into forward table and set index in meta
-    add_to_list(forward_table, evac_obj_data);
-    stack_push(Object*, pending_resets, obj); //delayed updates
-
-    // Decrementing reference to indicate that this instance is no longer used
-    decrement_ref_count(obj);
-
-    return evac_obj_data;
+    // Set post-canary
+    uint64_t* post = (uint64_t*)((char*)base + ALLOC_DEBUG_CANARY_SIZE + sizeof(MetaData) + entry_size);
+    *post = ALLOC_DEBUG_CANARY_VALUE;
 }
-
-void finalize_metadata_reset(struct Stack* to_be_reset) {
-    while(!s_is_empty(to_be_reset)) {
-        MetaData* needs_reset = META_FROM_OBJECT((Object*)s_pop(to_be_reset));
-        RESET_METADATA_FOR_OBJECT(needs_reset);
-    }
-}
-
-/* Helper to update an objects children pointers */
-void update_children_pointers(Object* obj, ArrayList* forward_table) {
-    for (int i = 0; i < obj->num_children; i++) {
-        Object* oldest = obj->children[i];
-
-        if(META_FROM_OBJECT(oldest)->forward_index != MAX_FWD_INDEX) {
-            obj->children[i] = forward_table->data[META_FROM_OBJECT(oldest)->forward_index];
-        } else {
-            obj->children[i] = oldest; // No evacuated object, keep original (may never occur)
-        }
-    }
-}
-
-void evacuate(struct Stack *marked_nodes_list, AllocatorBin *bin) {
-    ArrayList worklist;
-    Stack pending_resets;
-    initialize_list(&worklist);
-    stack_init(&pending_resets);
-
-    /**
-    * pending_resets contains old locations in memory of objects we evacuate into evac page.
-    * This is necessary so we can control when the blocks in pending_resets are returned back 
-    * to the free list of their respective page. This enables us to use metadata in these old
-    * locations to grab forward indexs and update parents child pointers.
-    **/
-
-    ArrayList* forward_table = &f_table;
-    if(!forward_table) {
-        initialize_list(forward_table);
-    }
-
-    while(!s_is_empty(marked_nodes_list)) {
-        Object* obj = (Object*)s_pop(marked_nodes_list);
-        
-        if(GC_IS_ROOT(obj) == false) {
-            if(obj->num_children == 0) {
-                evacuate_object(bin, obj, forward_table, &pending_resets);
-            } else {
-                // If the object we are trying to evacuate has children we will first update its children pointers then evacuate.
-                update_children_pointers(obj, forward_table);
-                evacuate_object(bin, obj, forward_table, &pending_resets);
-            }
-        } else{
-            // If the object we are trying to evacuate has children we will first update its children pointers then evacuate.
-            update_children_pointers(obj, forward_table);
-        }
-    }
-
-    finalize_metadata_reset(&pending_resets);
-}
-
-void rebuild_freelist(AllocatorBin* bin, PageInfo* page) {
-    page->freelist = NULL;
-    page->freecount = 0;
-
-    FreeListEntry* last_freelist_entry = NULL;
-    bool first_nonalloc_block = true;
-
-    for (size_t i = 0; i < page->entrycount; i++) {
-        FreeListEntry* new_freelist_entry = FREE_LIST_ENTRY_AT(page, i);
-        Object* obj = OBJ_FROM_FREELIST_ENTRY(new_freelist_entry);
-
-        if (GC_IS_ALLOCATED(obj) == false) {
-            if(first_nonalloc_block) {
-                page->freelist = new_freelist_entry;
-                page->freelist->next = NULL;
-                last_freelist_entry = page->freelist;
-                first_nonalloc_block = false;
-            } else {
-                last_freelist_entry->next = new_freelist_entry;
-                new_freelist_entry->next = NULL; 
-                last_freelist_entry = new_freelist_entry;
-            }
-            
-            page->freecount++;
-        }
-    }
-
-    /* If our page is completly clean rotate into backstore_pages */
-    if(page->freecount == page->entrycount) {
-        debug_print("[DEBUG] Copied empty page into backstore_pages\n");
-        s_push(&backstore_pages, page);
-    }
-
-    /**
-    * Currently I have no idea why I need to manually set the bins page here,
-    * I feel like manually doing this setting could create some really weird
-    * problems when running larger tests. It seems that modifying the current 
-    * page in bin through our page manager does not properly reflect in
-    * bin->page/freelist itself. hmm...
-    **/
-
-    /* Now update the current page for bin if there are freeblocks */
-    if(page->freecount > 0) {
-        bin->page = page;
-        bin->freelist = page->freelist;
-    }
-
-    debug_print("[DEBUG] Rebuilt freelist for page %p with %d free blocks\n", page, page->freecount);
-}
-
-// Just run through all pages and flag nodes that arent marked as non allocated --- may not be necessary
-void clean_nonref_nodes(AllocatorBin* bin) {
-    PageInfo* current_page = bin->page_manager->all_pages;
-
-    while(current_page != NULL) {
-        for(uint16_t i = 0; i < current_page->entrycount; i++) {
-            Object* current_object = OBJECT_AT(current_page, i);
-
-            /* Clear objects that are either not marked or non roots with zero ref count */
-            if((GC_IS_MARKED(current_object) == false && GC_IS_ALLOCATED(current_object) == true)
-                || (GC_IS_ROOT(current_object) == false && GC_REF_COUNT(current_object) == 0)) {
-                RESET_METADATA_FOR_OBJECT(META_FROM_OBJECT(current_object));
-            }
-        }
-
-        debug_print("[DEBUG] bin->freelist before rebuilding: %p\n", bin->freelist);
-        rebuild_freelist(bin, current_page);
-        debug_print("[DEBUG] bin->freelist after rebuilding: %p\n", bin->freelist);
-        current_page = current_page->next;
-    }
-} 
 #endif
 
-/* This will be integrated into our mark from roots method, for now just walks stack of program */
+static void* copy_object_data(void* old_addr, void* new_base, size_t entry_size) {
+    void* new_addr;
+
+#ifdef ALLOC_DEBUG_CANARY
+    // If canaries are enabled, skip the pre-canary and copy the object data + metadata
+    new_addr = (char*)new_base + ALLOC_DEBUG_CANARY_SIZE;
+    memcpy(new_addr, (char*)old_addr - sizeof(MetaData), entry_size + sizeof(MetaData));
+#else
+    // If canaries are not enabled, copy the object data + metadata directly
+    new_addr = new_base;
+    memcpy(new_addr, (char*)old_addr - sizeof(MetaData), entry_size + sizeof(MetaData));
+#endif
+
+    return new_addr;
+}
+
+void evacuate() 
+{
+    AllocatorBin* bin = &a_bin16; // This is not good
+    while(!stack_empty(marking_stack)) {
+        void* old_addr = stack_pop(void, marking_stack);
+
+        if(!GC_IS_ROOT(old_addr) && GC_IS_YOUNG(old_addr)) {
+            // Check if the current evacuation page's freelist is exhausted
+            if (bin->page_manager->evacuate_page->freelist == NULL) {
+                update_evacuation_freelist(bin);
+            }
+            
+            FreeListEntry* base = bin->page_manager->evacuate_page->freelist;
+            bin->page_manager->evacuate_page->freelist = base->next;
+            debug_print("evac freelist next %p\n", base->next);
+
+            set_canaries(base, bin->entrysize);
+        
+            void* new_addr = copy_object_data(old_addr, base, bin->entrysize);
+            debug_print("Moved %p to %p\n", old_addr, new_addr);
+        }
+    }
+}
+
 void walk_stack(struct Stack* marked_nodes, struct WorkList* worklist) 
 {
     loadNativeRootSet();
@@ -228,8 +92,9 @@ void walk_stack(struct Stack* marked_nodes, struct WorkList* worklist)
             if(GC_IS_ALLOCATED(addr) && (GC_TYPE(addr)->ptr_mask != LEAF_PTR_MASK) && canupdate) {
                 if(GC_REF_COUNT(addr) > 0) continue;
 
-                if(GC_IS_YOUNG(addr)) {
+                if(!GC_IS_YOUNG(addr)) {
                     /* Need some way to handle old roots */
+                    i++;
                     continue;
                 }
 
@@ -239,9 +104,9 @@ void walk_stack(struct Stack* marked_nodes, struct WorkList* worklist)
                     GC_IS_ROOT(addr) = true;
                     worklist_push(*worklist, addr);
                     stack_push(void, *marked_nodes, addr);
+                    debug_print("Found a root at %p storing 0x%x\n", addr, *(int*)addr);
                 }
 
-                debug_print("Found a root at %p storing 0x%x\n", addr, *(int*)addr);
             }
         }
 
@@ -271,7 +136,6 @@ void walk_stack(struct Stack* marked_nodes, struct WorkList* worklist)
 void mark_and_evacuate()
 {
     struct WorkList worklist;
-
     worklist_initialize(&worklist);
 
     walk_stack(&marking_stack, &worklist);
@@ -313,5 +177,5 @@ void mark_and_evacuate()
     }
     #endif
 
-    //evacuate(&marked_nodes, bin);
+    evacuate();
 }

--- a/src/runtime/memory/gc.h
+++ b/src/runtime/memory/gc.h
@@ -63,14 +63,14 @@ bool isRoot(void* obj);
 * have old children AND that they have non zero references. If any references drops to zero
 * we can free from this method.
 **/
-void collect(AllocatorBin* bin);
+void collect();
 
 /**
  * We have a list containing all children nodes that will need to be moved
  * over to our evacuate page(s). Traverse this list, move nodes, update
  * pointers from their parents.
  **/
-void evacuate(struct Stack* marked_nodes_list, AllocatorBin* bin); 
+void evacuate(); 
 
 /**
 * Iterates through page looking for objects whos ref count has dropped to zero,

--- a/test/memory/memex.c
+++ b/test/memory/memex.c
@@ -7,7 +7,7 @@ int main()
 
     test_stack_walk();
 
-    mark_and_evacuate();
+    collect();
     
     return 0;
 }

--- a/test/memory/memex.c
+++ b/test/memory/memex.c
@@ -5,9 +5,14 @@ int main()
     initializeStartup();
     initializeThreadLocalInfo();
 
-    test_stack_walk();
+    initializeAllocatorBin(ListNode.type_size);
+    initializeAllocatorBin(Empty.type_size);
 
+    test_stack_walk();
     collect();
     
+    test_stack_walk();
+    collect();
+
     return 0;
 }

--- a/test/memory/memex.c
+++ b/test/memory/memex.c
@@ -14,5 +14,8 @@ int main()
     test_stack_walk();
     collect();
 
+    test_stack_walk();
+    collect();
+
     return 0;
 }

--- a/test/stack_test.c
+++ b/test/stack_test.c
@@ -1,9 +1,8 @@
 #include "stack_test.h"
 
 int test_stack_walk() {
-    /* We assign these global pointers to hold addreses of stack variables, keeping them alive */
-    AllocatorBin* bin16 = initializeAllocatorBin(ListNode.type_size);
-    AllocatorBin* bin8 = initializeAllocatorBin(Empty.type_size);
+    AllocatorBin* bin16 = getBinForSize(16);
+    AllocatorBin* bin8 = getBinForSize(8);
 
     char try_to_make_weird_stack_pointer_offsets = 'a';
     debug_print("%i\n", try_to_make_weird_stack_pointer_offsets);

--- a/test/stack_test.c
+++ b/test/stack_test.c
@@ -12,6 +12,9 @@ int test_stack_walk() {
     void* end = allocate(bin8, &Empty);
     *((int64_t*)end) = 0xDEADBEF4; // Store some data in the end node
 
+    //void* tobe_collected = allocate(bin8, &Empty);
+    //*((int64_t*)tobe_collected) = 0xBADCABF0; 
+
     /* Create the linked list nodes */
     void* ln0 = allocate(bin16, &ListNode);
     void* ln1 = allocate(bin16, &ListNode);


### PR DESCRIPTION
- converted old "struct Object" based logic to use real roots found from walking the execution stack
- objects get moved to evacuation pages and have their pointers updated using naive forwarding table
- freelist rebuilt as last step scanning all pages to find objects who are not allocated or old, non root, and ref count zero

Next steps is going to be conversion of all pages into an array list and figuring out how to differentiate our roots pages (what is left after evacuation) from evacuation pages