### PR TITLE
Page management rework

### DIFF
--- a/src/runtime/common.h
+++ b/src/runtime/common.h
@@ -152,6 +152,17 @@ do {                                                 \
     (meta)->ref_count = 0;                           \
 } while(0)
 
+/* Macro for insertion of PageInfo object into list */
+#define INSERT_PAGE_IN_LIST(L, O) \
+do {                              \
+    if ((L) == NULL) {            \
+        (L) = (O);                \
+        (O)->next = NULL;         \
+    } else {                      \
+        (O)->next = (L);          \
+        (L) = (O);                \
+    }                             \
+} while (0)
 
 #ifdef ALLOC_DEBUG_CANARY
 

--- a/src/runtime/common.h
+++ b/src/runtime/common.h
@@ -47,8 +47,8 @@ void xmem_objclear(void* mem, size_t n);
 void xmem_pageclear(void* mem);
 
 // Gets min and max pointers on a page from any address in the page
-#define GET_MIN_FOR_SEGMENT(P, SEG) ((void**)(((uintptr_t)(P) & PAGE_ADDR_MASK) + SEG))
-#define GET_MAX_FOR_SEGMENT(P, SEG) ((void**)(((uintptr_t)(P) & PAGE_ADDR_MASK) + SEG + BSQ_BLOCK_ALLOCATION_SIZE - (SEG + sizeof(void*))))
+#define GET_MIN_FOR_SEGMENT(P, SEG_SIZE) ((void**)(((uintptr_t)(P) & PAGE_ADDR_MASK) + SEG_SIZE))
+#define GET_MAX_FOR_SEGMENT(P, SEG_SIZE) ((void**)(((uintptr_t)(P) & PAGE_ADDR_MASK) + SEG_SIZE + BSQ_BLOCK_ALLOCATION_SIZE - (SEG_SIZE + sizeof(void*))))
 
 extern mtx_t g_lock;
 extern size_t tl_id_counter;

--- a/src/runtime/memory/allocator.c
+++ b/src/runtime/memory/allocator.c
@@ -100,31 +100,20 @@ PageInfo* allocateFreshPage(uint16_t entrysize)
 
 void getFreshPageForAllocator(AllocatorBin* alloc)
 {   
+    PageInfo* page = getPageFromManager(alloc->page_manager, alloc->entrysize);
     /* Fetch a page from our manager and insert into alloc_page list */
-    if(alloc->alloc_page != NULL) {
-        alloc->alloc_page->next = getPageFromManager(alloc->page_manager, alloc->entrysize);
-        alloc->alloc_page = alloc->alloc_page->next;
-        alloc->alloc_page->next = NULL;
-    } 
-    else {
-        alloc->alloc_page = getPageFromManager(alloc->page_manager, alloc->entrysize);
-        alloc->alloc_page->next = NULL;
-    }
+    INSERT_PAGE_IN_LIST(alloc->alloc_page, page);
 
     alloc->freelist = alloc->alloc_page->freelist;
 }
 
 void getFreshPageForEvacuation(AllocatorBin* alloc) 
 {
-    if(alloc->evac_page != NULL) {
-        alloc->evac_page->next = getPageFromManager(alloc->page_manager, alloc->entrysize);
-        alloc->evac_page = alloc->evac_page->next;
-        alloc->evac_page->next = NULL;
-    }
-    else {
-        alloc->evac_page = getPageFromManager(alloc->page_manager, alloc->entrysize);
-        alloc->evac_page->next = NULL;
-    }
+    PageInfo* page = getPageFromManager(alloc->page_manager, alloc->entrysize);
+
+    INSERT_PAGE_IN_LIST(alloc->evac_page, page);
+
+    /* Need to update freelist? */
 }
 
 AllocatorBin* getBinForSize(uint16_t entrytsize)

--- a/src/runtime/memory/allocator.c
+++ b/src/runtime/memory/allocator.c
@@ -7,12 +7,12 @@
 #define CANARY_DEBUG_CHECK
 
 /* Static declarations of our allocator bin and page manager structures */
-AllocatorBin a_bin8 = {.freelist = NULL, .entrysize = 8, .page = NULL, .page_manager = NULL};
-AllocatorBin a_bin16 = {.freelist = NULL, .entrysize = 16, .page = NULL, .page_manager = NULL};
+AllocatorBin a_bin8 = {.freelist = NULL, .entrysize = 8, .alloc_page = NULL, .evac_page = NULL, .page_manager = &p_mgr8};
+AllocatorBin a_bin16 = {.freelist = NULL, .entrysize = 16, .alloc_page = NULL, .evac_page = NULL, .page_manager = &p_mgr16};
 
 /* Each AllocatorBin needs its own page manager */
-PageManager p_mgr8 = {.all_pages = NULL, .evacuate_page = NULL, .filled_pages = NULL};
-PageManager p_mgr16 = {.all_pages = NULL, .evacuate_page = NULL, .filled_pages = NULL};
+PageManager p_mgr8 = {.low_utilization_pages = NULL, .mid_utilization_pages = NULL, .high_utilization_pages = NULL, .filled_pages = NULL, .empty_pages = NULL};
+PageManager p_mgr16 = {.low_utilization_pages = NULL, .mid_utilization_pages = NULL, .high_utilization_pages = NULL, .filled_pages = NULL, .empty_pages = NULL};
 
 static void setup_freelist(PageInfo* pinfo, uint16_t entrysize) {
     FreeListEntry* current = pinfo->freelist;
@@ -41,8 +41,42 @@ static PageInfo* initializePage(void* page, uint16_t entrysize)
 }
 
 /**
-* Whenever this method is called we need to insert address into our hierarchical page manager so its easy to 
-* see if said page exists.
+* Go into a bins page manager and grab us a page. This will need some rework in the future
+* to where we can decide more specifically what page utilizaiton levels we want for a specific
+* purpose. Ex if we want an evac page we may be more inclined to grab a full page. Or an alloc
+* page could be more useful to be mostly empty since most objects on it will die.
+**/
+PageInfo* getPageFromManager(PageManager* pm, uint16_t entrysize) 
+{
+    PageInfo* page = NULL;
+
+    if(pm->empty_pages != NULL) {
+        page = pm->empty_pages;
+        pm->empty_pages = pm->empty_pages->next;
+    }
+    else if(pm->low_utilization_pages != NULL) {
+        page = pm->low_utilization_pages;
+        pm->low_utilization_pages = pm->low_utilization_pages->next;
+    }
+    else if(pm->mid_utilization_pages != NULL) {
+        page = pm->mid_utilization_pages;
+        pm->mid_utilization_pages = pm->mid_utilization_pages->next;
+    } 
+    else if(pm->high_utilization_pages != NULL) {
+        page = pm->high_utilization_pages;
+        pm->high_utilization_pages = pm->high_utilization_pages->next;
+    }
+    else {
+        page = allocateFreshPage(entrysize);
+    }
+
+    return page;
+}
+
+/**
+* Insert into our mulitlevel page manager. We do not need to insert into page manager here
+* because we are assuming this page will directly be needed for allocation. No point in 
+* inserting into empty_pages just to have to go and grab it right away. Saves pointer overhead.
 **/
 PageInfo* allocateFreshPage(uint16_t entrysize)
 {
@@ -65,60 +99,41 @@ PageInfo* allocateFreshPage(uint16_t entrysize)
 }
 
 void getFreshPageForAllocator(AllocatorBin* alloc)
-{
-    if(alloc->page != NULL) {
-        //need to rotate our old page into the collector, now alloc->page
-        //exists in the needs_collection list
-        alloc->page->pagestate = AllocPageInfo_ActiveEvacuation;
-        alloc->page->next = alloc->page_manager->filled_pages;
-        alloc->page_manager->filled_pages = alloc->page;
+{   
+    /* Fetch a page from our manager and insert into alloc_page list */
+    if(alloc->alloc_page != NULL) {
+        alloc->alloc_page->next = getPageFromManager(alloc->page_manager, alloc->entrysize);
+        alloc->alloc_page = alloc->alloc_page->next;
+        alloc->alloc_page->next = NULL;
+    } 
+    else {
+        alloc->alloc_page = getPageFromManager(alloc->page_manager, alloc->entrysize);
+        alloc->alloc_page->next = NULL;
     }
-    PageInfo* new_page = allocateFreshPage(alloc->entrysize);
 
-    // Add new page to all pages list
-    new_page->next = alloc->page_manager->all_pages;
-    alloc->page_manager->all_pages = new_page;
-
-    // Make sure the current alloc page points to this entry in the list
-    alloc->page = new_page;
-    alloc->freelist = new_page->freelist;
+    alloc->freelist = alloc->alloc_page->freelist;
 }
 
-AllocatorBin* initializeAllocatorBin(uint16_t entrysize)
+void getFreshPageForEvacuation(AllocatorBin* alloc) 
 {
-    /* Not too sure about using entry size to determine what bin to use here */
-    AllocatorBin* bin = NULL;
-    if(entrysize == 8) {
-        bin = &a_bin8;
-        bin->page_manager = &p_mgr8;
-    }else if (entrysize == 16) {
-        bin = &a_bin16;
-        bin->page_manager = &p_mgr16;
+    if(alloc->evac_page != NULL) {
+        alloc->evac_page->next = getPageFromManager(alloc->page_manager, alloc->entrysize);
+        alloc->evac_page = alloc->evac_page->next;
+        alloc->evac_page->next = NULL;
     }
-    assert(bin != NULL);
-
-    if(bin == NULL) return NULL;
-
-    bin->page_manager->evacuate_page = allocateFreshPage(entrysize);
-
-    getFreshPageForAllocator(bin);
-
-    return bin;
+    else {
+        alloc->evac_page = getPageFromManager(alloc->page_manager, alloc->entrysize);
+        alloc->evac_page->next = NULL;
+    }
 }
 
 AllocatorBin* getBinForSize(uint16_t entrytsize)
 {
     switch(entrytsize){
         case 8: {
-            if(a_bin8.page == NULL) {
-                return initializeAllocatorBin(8);
-            }
             return &a_bin8;
         }
         case 16: {
-            if(a_bin8.page == NULL) {
-                return initializeAllocatorBin(16);
-            }
             return &a_bin16;
         }
         default: return NULL;

--- a/src/runtime/memory/allocator.h
+++ b/src/runtime/memory/allocator.h
@@ -97,6 +97,8 @@ typedef struct AllocatorBin
     * We will store roots, pending decs, maybe a worklist
     * and other nice bin local structures 
     */
+    struct ArrayList roots;
+    struct ArrayList old_roots;
 
     PageInfo* alloc_page; // Page in which we are currently allocating from
     PageInfo* evac_page; // Page in which we are currently evacuating from
@@ -143,7 +145,7 @@ PageManager* initializePageManager(uint16_t entry_size);
 PageInfo* allocateFreshPage(uint16_t entrysize);
 
 /**
- * Slow path for usage with canaries --- debug
+ * Slow path for usage with canaries
  **/
 static inline void* setupSlowPath(FreeListEntry* ret, AllocatorBin* alloc){
     uint64_t* pre = (uint64_t*)ret;

--- a/src/runtime/memory/allocator.h
+++ b/src/runtime/memory/allocator.h
@@ -39,6 +39,16 @@ do {                                    \
     (M)->type = T;                      \
 } while(0)
 
+/**
+* This whole memory allocator needs some more thought. A new idea is
+* instead of each bin maininting its own page manager, we have a global page
+* manager in which they all share. Then what we could do is each page has
+* a pointer to "next" that is to be used bin locally and also a global pointer
+* into the overarching global page manager that links together all pages. We can throw
+* around this next pointer, however the manager_next or something will need to
+* be a bit more concrete.
+**/
+
 ////////////////////////////////
 //Memory allocator
 
@@ -66,25 +76,39 @@ typedef struct PageInfo
 
     PageStateInfo pagestate;
 
-    struct PageInfo* next; //need this for allocator page management
+    struct PageInfo* next;
 } PageInfo;
 
 typedef struct PageManager{
-    PageInfo* all_pages;
-    PageInfo* evacuate_page;
-    PageInfo* filled_pages; //Array list?
+    PageInfo* low_utilization_pages; // Pages with 1-30% utilization (does not hold fully empty)
+    PageInfo* mid_utilization_pages; // Pages with 31-85% utilization
+    PageInfo* high_utilization_pages; // Pages with 86-100% utilization 
+
+    PageInfo* filled_pages; // Completly empty pages
+    PageInfo* empty_pages; // Completeyly full pages
 } PageManager;
-extern PageManager p_mgr;
 
 typedef struct AllocatorBin
 {
     FreeListEntry* freelist;
     uint16_t entrysize;
-    PageInfo* page;
+
+    /* 
+    * We will store roots, pending decs, maybe a worklist
+    * and other nice bin local structures 
+    */
+
+    PageInfo* alloc_page; // Page in which we are currently allocating from
+    PageInfo* evac_page; // Page in which we are currently evacuating from
     PageManager* page_manager;
 } AllocatorBin;
+
+/* Since entry sizes varry, we can statically declare bins & page managers to avoid any mallocs */
 extern AllocatorBin a_bin8;
+extern PageManager p_mgr8;
+
 extern AllocatorBin a_bin16;
+extern PageManager p_mgr16;
 
 /**
  * When needed, get a fresh page from mmap to allocate from 
@@ -92,9 +116,15 @@ extern AllocatorBin a_bin16;
 void getFreshPageForAllocator(AllocatorBin* alloc);
 
 /**
- * For our allocator to be usable, the AllocatorBin must be initialized
- **/
-AllocatorBin* initializeAllocatorBin(uint16_t entrysize);
+* If we cannot find a page to evacuate to use this
+**/
+void getFreshPageForEvacuation(AllocatorBin* alloc); 
+
+/**
+* Gets ptr to page from a bins manager that we can manipulate using
+* its bin_next pointer
+**/
+PageInfo* getPageFromManager(PageManager* pm, uint16_t entrysize);
 
 /**
 * Since our bins can vary in size (always multiple of 8 bytes) depending on the type they hold
@@ -103,8 +133,7 @@ AllocatorBin* initializeAllocatorBin(uint16_t entrysize);
 AllocatorBin* getBinForSize(uint16_t entrytsize);
 
 /**
- * Setup pointers for managing our pages 
- * we have a list of all pages and those that have stuff in them
+ * Sets up metafields for PageInfo
  **/
 PageManager* initializePageManager(uint16_t entry_size);
 

--- a/src/runtime/memory/allocator.h
+++ b/src/runtime/memory/allocator.h
@@ -176,5 +176,6 @@ static inline void* allocate(AllocatorBin* alloc, struct TypeInfoBase* type)
     MetaData* mdata = (MetaData*)((char*)obj - sizeof(MetaData));
     SETUP_META_FLAGS(mdata, type);
 
+    debug_print("Allocated object at %p\n", obj);
     return (void*)obj;
 }

--- a/src/runtime/memory/allocator.h
+++ b/src/runtime/memory/allocator.h
@@ -176,6 +176,8 @@ static inline void* allocate(AllocatorBin* alloc, struct TypeInfoBase* type)
     MetaData* mdata = (MetaData*)((char*)obj - sizeof(MetaData));
     SETUP_META_FLAGS(mdata, type);
 
+    alloc->alloc_page->freecount--;
+
     debug_print("Allocated object at %p\n", obj);
     return (void*)obj;
 }

--- a/src/runtime/memory/gc.c
+++ b/src/runtime/memory/gc.c
@@ -168,12 +168,6 @@ void rebuild_freelist()
             * bin->page/freelist itself. hmm...
             **/
 
-            /* Now update the current page for bin if there are freeblocks */
-            if(cur->freecount > 0) {
-                bin->alloc_page = cur;
-                bin->freelist = cur->freelist;
-            }
-
             debug_print("[DEBUG] Freelist %p rebuild. Page contains %i allocated blocks.\n", cur->freelist, cur->entrycount - cur->freecount);
 
             /* return cur page to its bins page manager */

--- a/src/runtime/support/arraylist.c
+++ b/src/runtime/support/arraylist.c
@@ -14,7 +14,7 @@ void arraylist_push_head_slow(struct ArrayList* al, void* obj)
 {
     /* A tad "weirder" than adding a tail. We neeed to make a new page and set our head to its max element */
     struct ArrayListSegment* xseg = XALLOC_PAGE(struct ArrayListSegment);
-    debug_print("NEW PAGE!!!!!!\n");
+    debug_print("NEW ARRAY LIST PAGE!!!!!!\n");
     xseg->data = (void*)((char*)xseg + sizeof(struct ArrayListSegment));
 
     /* Case when no pages have been linked */
@@ -43,7 +43,7 @@ void arraylist_push_head_slow(struct ArrayList* al, void* obj)
 void arraylist_push_tail_slow(struct ArrayList* al, void* obj)
 { 
     struct ArrayListSegment* xseg = XALLOC_PAGE(struct ArrayListSegment);
-    debug_print("NEW PAGE!!!!!!\n");
+    debug_print("NEW ARRAY LIST PAGE!!!!!!\n");
     xseg->data = (void*)((char*)xseg + sizeof(struct ArrayListSegment));
 
     /* Case when no pages have been linked */
@@ -113,5 +113,31 @@ void* arraylist_pop_tail_slow(struct ArrayList* al)
     }
 
     return res;
+}
+
+void** arraylist_get_iterator(struct ArrayList* al) {
+    return al->head;
+}
+
+void* arraylist_get_next(struct ArrayList* al, void** it) {
+    if(it == GET_MAX_FOR_SEGMENT(it, AL_SEG_SIZE)) {
+        struct ArrayListSegment* cur_segment = 
+            (struct ArrayListSegment*)((uintptr_t)it & PAGE_ADDR_MASK);
+        it = GET_MIN_FOR_SEGMENT(cur_segment->next, AL_SEG_SIZE);
+    }
+    else {
+        it++;
+    }
+
+    return it;
+}
+
+bool arraylist_is_empty(struct ArrayList* al) {
+    /* It is crucial we check the contents of these pointers, not addresses they hold */
+    return *al->head == NULL || *al->tail == NULL; 
+}
+
+bool arraylist_is_init(struct ArrayList* al) {
+    return al->head_segment && al->tail_segment;
 }
     

--- a/src/runtime/support/arraylist.h
+++ b/src/runtime/support/arraylist.h
@@ -38,4 +38,11 @@ void arraylist_push_head_slow(struct ArrayList* al, void* obj);
 void arraylist_push_tail_slow(struct ArrayList* al, void* obj);
 void* arraylist_pop_head_slow(struct ArrayList* al);
 void* arraylist_pop_tail_slow(struct ArrayList* al);
+
+void** arraylist_get_iterator(struct ArrayList* al);
+void* arraylist_get_next(struct ArrayList* al, void** it);
+
+bool arraylist_is_empty(struct ArrayList* al);
+bool arraylist_is_init(struct ArrayList* al);
+
     

--- a/src/runtime/support/pagetable.c
+++ b/src/runtime/support/pagetable.c
@@ -14,11 +14,11 @@ void pagetable_init() {
 }
 
 void pagetable_insert(void* addr) {
-    uint64_t address = (uint64_t)addr;
-    uint64_t index1 = (address >> LEVEL1_SHIFT) & LEVEL_MASK; // Bits 47-36
-    uint64_t index2 = (address >> LEVEL2_SHIFT) & LEVEL_MASK; // Bits 35-24
-    uint64_t index3 = (address >> LEVEL3_SHIFT) & LEVEL_MASK; // Bits 23-12
-    uint64_t index4 = address & LEVEL_MASK;                   // Bits 11-0
+    uintptr_t address = (uintptr_t)addr;
+    uintptr_t index1 = (address >> LEVEL1_SHIFT) & LEVEL_MASK; // Bits 47-36
+    uintptr_t index2 = (address >> LEVEL2_SHIFT) & LEVEL_MASK; // Bits 35-24
+    uintptr_t index3 = (address >> LEVEL3_SHIFT) & LEVEL_MASK; // Bits 23-12
+    uintptr_t index4 = address & LEVEL_MASK;                   // Bits 11-0
 
     void** level1 = pagetable_root;
     if (!level1[index1]) {
@@ -43,11 +43,11 @@ void pagetable_insert(void* addr) {
 }
 
 bool pagetable_query(void* addr) {
-    uint64_t address = (uint64_t)addr;
-    uint64_t index1 = (address >> LEVEL1_SHIFT) & LEVEL_MASK;  // Bits 47-36
-    uint64_t index2 = (address >> LEVEL2_SHIFT) & LEVEL_MASK;  // Bits 35-24
-    uint64_t index3 = (address >> LEVEL3_SHIFT) & LEVEL_MASK;  // Bits 23-12
-    uint64_t index4 = (address & PAGE_ADDR_MASK) & LEVEL_MASK; // Bits 11-0
+    uintptr_t address = (uintptr_t)addr;
+    uintptr_t index1 = (address >> LEVEL1_SHIFT) & LEVEL_MASK;  // Bits 47-36
+    uintptr_t index2 = (address >> LEVEL2_SHIFT) & LEVEL_MASK;  // Bits 35-24
+    uintptr_t index3 = (address >> LEVEL3_SHIFT) & LEVEL_MASK;  // Bits 23-12
+    uintptr_t index4 = (address & PAGE_ADDR_MASK) & LEVEL_MASK; // Bits 11-0
 
     void** level1 = pagetable_root;
     if (!level1[index1]) return false;

--- a/src/runtime/support/threadinfo.c
+++ b/src/runtime/support/threadinfo.c
@@ -63,6 +63,8 @@ void loadNativeRootSet()
                 void* potential_ptr = *it;
                 if (PTR_IN_RANGE(potential_ptr) && PTR_NOT_IN_STACK(native_stack_base, end_of_frame, potential_ptr)) {
                     native_stack_contents[i++] = potential_ptr;
+
+                    debug_print("found potential pointer at %p\n", potential_ptr);
                 }
                 it--;
             }

--- a/test/tree_basic.c
+++ b/test/tree_basic.c
@@ -24,7 +24,7 @@ struct TypeInfoBase TreeNode = {
     .typekey = "TreeNode"
 };
 
-int main(int argc, char** argv) {
+int run() {
     initializeStartup();
     initializeThreadLocalInfo();
 
@@ -41,10 +41,12 @@ int main(int argc, char** argv) {
 
     debug_print("%p %p %p \n", root, leaf1, leaf2);
 
-    collect(); // First GC cycle
-
     return 0;
 }
 
+int main(int argc, char** argv) {
+    run();
+    collect();
 
-
+    return 0;
+}

--- a/test/tree_basic.c
+++ b/test/tree_basic.c
@@ -1,6 +1,4 @@
-#include "../src/language/bsqtype.h"
-#include "../src/runtime/memory/allocator.h"
-#include "../src/runtime/support/threadinfo.h"
+#include "../src/runtime/memory/gc.h"
 
 struct TypeInfoBase Empty = {
     .type_id = 0,
@@ -36,8 +34,16 @@ int main(int argc, char** argv) {
     AllocatorBin* bin8 = getBinForSize(8);
 
     void** root = (void**)allocate(bin16, &TreeNode);
+    void** root1 = (void**)allocate(bin16, &TreeNode);
+
     void* leaf1 = allocate(bin8, &Empty);
     void* leaf2 = allocate(bin8, &Empty);
+
+    //*((int64_t*)leaf1) = 0xDEADBEF0;
+    //*((int64_t*)leaf2) = 0xDEADBEF1;
+
+    root1[0] = leaf1;
+    root1[2] = leaf2;
 
     root[0] = leaf1;
     root[1] = leaf2;
@@ -46,5 +52,8 @@ int main(int argc, char** argv) {
 
     debug_print("Hello from tree_basic test\n");
 
+    collect();
+
     return 0;
 }
+

--- a/test/tree_basic.c
+++ b/test/tree_basic.c
@@ -21,39 +21,30 @@ struct TypeInfoBase TreeNode = {
     .type_size = 16,
     .slot_size = 2,
     .ptr_mask = "11",  
-    .typekey = "ListNode"
+    .typekey = "TreeNode"
 };
 
-/* Lets create a simple tree and collect */
 int main(int argc, char** argv) {
-    /* Setup necessary bin and thread related stuff */
     initializeStartup();
     initializeThreadLocalInfo();
 
     AllocatorBin* bin16 = getBinForSize(16);
     AllocatorBin* bin8 = getBinForSize(8);
 
-    void** root = (void**)allocate(bin16, &TreeNode);
-    void** root1 = (void**)allocate(bin16, &TreeNode);
+    void** root = (void**)allocate(bin16, &TreeNode); // Root stays in main()
 
     void* leaf1 = allocate(bin8, &Empty);
     void* leaf2 = allocate(bin8, &Empty);
 
-    //*((int64_t*)leaf1) = 0xDEADBEF0;
-    //*((int64_t*)leaf2) = 0xDEADBEF1;
-
-    root1[0] = leaf1;
-    root1[2] = leaf2;
-
     root[0] = leaf1;
     root[1] = leaf2;
 
-    // Need to do some asserts now
+    debug_print("%p %p %p \n", root, leaf1, leaf2);
 
-    debug_print("Hello from tree_basic test\n");
-
-    collect();
+    collect(); // First GC cycle
 
     return 0;
 }
+
+
 


### PR DESCRIPTION
- bin local page managers now use low, mid, high utilization and empty/filled pages for management
- bin themselves now hold alloc and evac pages such that they can simply go fetch a page when necessary from their local manager, or if there are no fitting pages allocate a fresh one
- root set (and old roots although this is not used yet due to lack of proper ref counting) is now bin local and uses array list
- a few new arraylist friends

Essentially all of these changes are to get the gc well setup for implementing reference counting and integration of larger more through tests