### PR TITLE
Refcount integration

### DIFF
--- a/src/runtime/common.h
+++ b/src/runtime/common.h
@@ -122,6 +122,21 @@ extern size_t tl_id_counter;
 
 #define MAX_FWD_INDEX UINT32_MAX
 
+/**
+* Some allocator bin related constants 
+**/
+
+/* Only have 2 different bins (for now) */
+#define NUM_BINS 2
+
+/**
+* If we decide every 4mb we run a collection, we can just force the max number of roots to be capped
+* at 4mb. This even accounts for worst case where every single object is a root AND all new/old only
+*
+**/
+#define GC_COLLECTION_THRESHOLD 4000000 //4mb
+#define MAX_ROOTS GC_COLLECTION_THRESHOLD //maybe some other stuff
+
 #ifdef VERBOSE_HEADER
 typedef struct MetaData 
 {

--- a/src/runtime/memory/allocator.c
+++ b/src/runtime/memory/allocator.c
@@ -7,8 +7,8 @@
 #define CANARY_DEBUG_CHECK
 
 /* Static declarations of our allocator bin and page manager structures */
-AllocatorBin a_bin8 = {.freelist = NULL, .entrysize = 8, .alloc_page = NULL, .evac_page = NULL, .page_manager = &p_mgr8};
-AllocatorBin a_bin16 = {.freelist = NULL, .entrysize = 16, .alloc_page = NULL, .evac_page = NULL, .page_manager = &p_mgr16};
+AllocatorBin a_bin8 = {.freelist = NULL, .entrysize = 8, .roots_count = 0, .old_roots_count = 0, .alloc_page = NULL, .evac_page = NULL, .page_manager = &p_mgr8};
+AllocatorBin a_bin16 = {.freelist = NULL, .entrysize = 16, .roots_count = 0, .old_roots_count = 0, .alloc_page = NULL, .evac_page = NULL, .page_manager = &p_mgr16};
 
 /* Each AllocatorBin needs its own page manager */
 PageManager p_mgr8 = {.low_utilization_pages = NULL, .mid_utilization_pages = NULL, .high_utilization_pages = NULL, .filled_pages = NULL, .empty_pages = NULL};

--- a/src/runtime/memory/allocator.h
+++ b/src/runtime/memory/allocator.h
@@ -88,17 +88,17 @@ typedef struct PageManager{
     PageInfo* empty_pages; // Completeyly full pages
 } PageManager;
 
+/* Only have 2 different bins (for now) */
+#define NUM_BINS 2
 typedef struct AllocatorBin
 {
     FreeListEntry* freelist;
     uint16_t entrysize;
 
-    /* 
-    * We will store roots, pending decs, maybe a worklist
-    * and other nice bin local structures 
-    */
     struct ArrayList roots;
     struct ArrayList old_roots;
+
+    struct WorkList pending_decs;
 
     PageInfo* alloc_page; // Page in which we are currently allocating from
     PageInfo* evac_page; // Page in which we are currently evacuating from

--- a/src/runtime/memory/allocator.h
+++ b/src/runtime/memory/allocator.h
@@ -88,15 +88,17 @@ typedef struct PageManager{
     PageInfo* empty_pages; // Completeyly full pages
 } PageManager;
 
-/* Only have 2 different bins (for now) */
-#define NUM_BINS 2
 typedef struct AllocatorBin
 {
     FreeListEntry* freelist;
     uint16_t entrysize;
 
-    struct ArrayList roots;
-    struct ArrayList old_roots;
+    /* Proved to be difficult to work with sorting, using static arrays for now */
+    void* roots[MAX_ROOTS];
+    void* old_roots[MAX_ROOTS];
+
+    size_t roots_count;
+    size_t old_roots_count;
 
     struct WorkList pending_decs;
 

--- a/src/runtime/memory/gc.h
+++ b/src/runtime/memory/gc.h
@@ -38,12 +38,14 @@ void mark_and_evacuate();
 void walk_stack(struct WorkList* worklist);
 
 /* Incremented in marking */
-static inline void increment_ref_count(void* obj) {
+static inline void increment_ref_count(void* obj) 
+{
     GC_REF_COUNT(obj)++;
 }
 
 /* Old location decremented in evacuation */
-static inline void decrement_ref_count(void* obj) {   
+static inline void decrement_ref_count(void* obj) 
+{   
     if(GC_REF_COUNT(obj) > 0) {
         GC_REF_COUNT(obj)--;
     }

--- a/src/runtime/memory/gc.h
+++ b/src/runtime/memory/gc.h
@@ -48,7 +48,7 @@ static inline void decrement_ref_count(void* obj) {
         GC_REF_COUNT(obj)--;
     }
 
-    // Maybe free object if not root and ref count 0 here?
+    // might make more sense to put back on freelist here if refcnt 0
 }
 
 /* Idk of a good forever home for these canary methods */

--- a/src/runtime/support/arraylist.c
+++ b/src/runtime/support/arraylist.c
@@ -132,6 +132,13 @@ void* arraylist_get_next(struct ArrayList* al, void** it) {
     return it;
 }
 
+/**
+* Sort list based on pointer addresses so we can easily compare roots and old_roots
+**/
+void arraylist_sort(struct ArrayList* al) {
+    
+}
+
 bool arraylist_is_empty(struct ArrayList* al) {
     /* It is crucial we check the contents of these pointers, not addresses they hold */
     return *al->head == NULL || *al->tail == NULL; 

--- a/src/runtime/support/arraylist.h
+++ b/src/runtime/support/arraylist.h
@@ -42,6 +42,8 @@ void* arraylist_pop_tail_slow(struct ArrayList* al);
 void** arraylist_get_iterator(struct ArrayList* al);
 void* arraylist_get_next(struct ArrayList* al, void** it);
 
+void arraylist_sort(struct ArrayList* al);
+
 bool arraylist_is_empty(struct ArrayList* al);
 bool arraylist_is_init(struct ArrayList* al);
 

--- a/src/runtime/support/threadinfo.c
+++ b/src/runtime/support/threadinfo.c
@@ -37,7 +37,6 @@ void initializeThreadLocalInfo()
     native_stack_base = rbp;
 }
 
-/* Need to discuss specifics of this walking, not totally sure about taking the potential ptr to be cur_frame + 1 */
 void loadNativeRootSet()
 {
     native_stack_contents = (void**)xallocAllocatePage();
@@ -45,7 +44,6 @@ void loadNativeRootSet()
 
     //this code should load from the asm stack pointers and copy the native stack into the roots memory
     #ifdef __x86_64__
-        /* originally current_frame used rsp */
         register void* rbp asm("rbp");
         register void* rsp asm("rsp");
         void** current_frame = rbp;
@@ -97,3 +95,20 @@ void unloadNativeRootSet()
 {
     xallocFreePage(native_stack_contents);
 }
+
+/* Walks from rsp to native stack base, not base to rsp*/
+#if 0
+
+        register void* rsp asm("rsp");
+        void** current_frame = rsp;
+        int i = 0;
+
+        while (current_frame < native_stack_base) {
+            void* potential_ptr = *(current_frame + 1);
+            if (PTR_IN_RANGE(potential_ptr) & PTR_NOT_IN_STACK(native_stack_base, current_frame, potential_ptr)) {
+                native_stack_contents[i++] = potential_ptr;
+            }
+            current_frame++;
+        }
+
+#endif

--- a/src/runtime/support/threadinfo.c
+++ b/src/runtime/support/threadinfo.c
@@ -61,8 +61,6 @@ void loadNativeRootSet()
                 void* potential_ptr = *it;
                 if (PTR_IN_RANGE(potential_ptr) && PTR_NOT_IN_STACK(native_stack_base, end_of_frame, potential_ptr)) {
                     native_stack_contents[i++] = potential_ptr;
-
-                    debug_print("found potential pointer at %p\n", potential_ptr);
                 }
                 it--;
             }

--- a/test/tree_basic.c
+++ b/test/tree_basic.c
@@ -31,7 +31,7 @@ int run() {
     AllocatorBin* bin16 = getBinForSize(16);
     AllocatorBin* bin8 = getBinForSize(8);
 
-    void** root = (void**)allocate(bin16, &TreeNode); // Root stays in main()
+    void** root = (void**)allocate(bin16, &TreeNode);
 
     void* leaf1 = allocate(bin8, &Empty);
     void* leaf2 = allocate(bin8, &Empty);
@@ -45,6 +45,9 @@ int run() {
 }
 
 int main(int argc, char** argv) {
+    run();
+    collect();
+
     run();
     collect();
 

--- a/test/tree_basic.c
+++ b/test/tree_basic.c
@@ -25,9 +25,6 @@ struct TypeInfoBase TreeNode = {
 };
 
 int run() {
-    initializeStartup();
-    initializeThreadLocalInfo();
-
     AllocatorBin* bin16 = getBinForSize(16);
     AllocatorBin* bin8 = getBinForSize(8);
 
@@ -39,12 +36,19 @@ int run() {
     root[0] = leaf1;
     root[1] = leaf2;
 
-    debug_print("%p %p %p \n", root, leaf1, leaf2);
+    debug_print("%p %p %p\n", root, leaf1, leaf2);
 
     return 0;
 }
 
+/**
+* If we do not initialize startup and thread stuff from main THEN do our allocations
+* ceratin objects do not get found on the stack. 
+**/
 int main(int argc, char** argv) {
+    initializeStartup();
+    initializeThreadLocalInfo();
+
     run();
     collect();
 

--- a/test/tree_basic.c
+++ b/test/tree_basic.c
@@ -36,6 +36,8 @@ int run() {
     root[0] = leaf1;
     root[1] = leaf2;
 
+    collect();
+
     debug_print("%p %p %p\n", root, leaf1, leaf2);
 
     return 0;
@@ -50,10 +52,7 @@ int main(int argc, char** argv) {
     initializeThreadLocalInfo();
 
     run();
-    collect();
-
     run();
-    collect();
 
     return 0;
 }


### PR DESCRIPTION
This is more over the core of what is needed to start ref counting. It (almost surely) doesn't work quite well since I haven't tested it deeply, but all the core pieces are present.

- Decided to go back to using static roots and old_roots in each bin to make quick sort easy (this may change)
- Now able to compare old roots and new roots set to determine if a root is eligible to be dec'd and maybe freed
- The actual logic itself for decrementing is implemented, iterating though an objects references, checking their ref counts, putting on pending_decs worklist then freeing if possible (just inserting into its pages freelist)