### PR TITLE
Adding support for a globals section (also useful for testing)

### DIFF
--- a/src/runtime/common.h
+++ b/src/runtime/common.h
@@ -96,6 +96,8 @@ extern mtx_t g_gcrefctlock;
 #define GC_REFCT_LOCK_ACQUIRE() assert(mtx_lock(&g_gcrefctlock) == thrd_success)
 #define GC_REFCT_LOCK_RELEASE() assert(mtx_unlock(&g_gcrefctlock) == thrd_success)
 
+#define INIT_LOCKS() { ALLOC_LOCK_INIT(); GC_MEM_LOCK_INIT(); GC_REFCT_LOCK_INIT(); }
+
 // Track information that needs to be globally accessible for threads
 class GlobalThreadAllocInfo
 {

--- a/src/runtime/memory/allocator.cpp
+++ b/src/runtime/memory/allocator.cpp
@@ -1,6 +1,6 @@
 #include "allocator.h"
 
-GlobalDataStorage g_global_data;
+GlobalDataStorage GlobalDataStorage::g_global_data;
 
 PageInfo* PageInfo::initialize(void* block, uint16_t allocsize, uint16_t realsize) noexcept
 {

--- a/src/runtime/memory/allocator.cpp
+++ b/src/runtime/memory/allocator.cpp
@@ -1,5 +1,7 @@
 #include "allocator.h"
 
+GlobalDataStorage g_global_data;
+
 PageInfo* PageInfo::initialize(void* block, uint16_t allocsize, uint16_t realsize) noexcept
 {
     PageInfo* pp = (PageInfo*)block;

--- a/src/runtime/memory/allocator.h
+++ b/src/runtime/memory/allocator.h
@@ -30,6 +30,28 @@
 ////////////////////////////////
 //Memory allocator
 
+//global storage for constant data (and testing support)
+//  -- Only a single thread may run while initializing the global roots as they are visible to all threads
+//  -- After initialization a GC must be run to promote all values to old ref-count space
+//  -- TODO: when we add multi-threading we need to use the special root-ref tag for these roots as well -- then we can skip re-scanning these after the promotion collection
+
+class GlobalDataStorage
+{
+public:
+    void* native_global_storage;
+    void* native_global_storage_end;
+
+    GlobalDataStorage() noexcept : native_global_storage(nullptr), native_global_storage_end(nullptr) { }
+
+    static GlobalDataStorage g_global_data;
+
+    void initialize(size_t numbytes, void* data) noexcept
+    {
+        this->native_global_storage = data;
+        this->native_global_storage_end = (void*)((uint8_t*)data + numbytes);
+    }
+};
+
 struct FreeListEntry
 {
    FreeListEntry* next;

--- a/src/runtime/memory/allocator.h
+++ b/src/runtime/memory/allocator.h
@@ -38,17 +38,17 @@
 class GlobalDataStorage
 {
 public:
-    void* native_global_storage;
-    void* native_global_storage_end;
+    void** native_global_storage;
+    void** native_global_storage_end;
 
     GlobalDataStorage() noexcept : native_global_storage(nullptr), native_global_storage_end(nullptr) { }
 
     static GlobalDataStorage g_global_data;
 
-    void initialize(size_t numbytes, void* data) noexcept
+    void initialize(size_t numbytes, void** data) noexcept
     {
         this->native_global_storage = data;
-        this->native_global_storage_end = (void*)((uint8_t*)data + numbytes);
+        this->native_global_storage_end = (void**)((uint8_t*)data + numbytes);
     }
 };
 

--- a/src/runtime/memory/gc.cpp
+++ b/src/runtime/memory/gc.cpp
@@ -201,6 +201,20 @@ void checkPotentialPtr(void* addr, BSQMemoryTheadLocalInfo& tinfo) noexcept
 
 void walkStack(BSQMemoryTheadLocalInfo& tinfo) noexcept 
 {
+    //Process global data (TODO -- later have flag to disable this after it is fixed as immortal)
+    if(GlobalDataStorage::g_global_data.native_global_storage != nullptr) {
+        void* curr = GlobalDataStorage::g_global_data.native_global_storage;
+        while(curr < GlobalDataStorage::g_global_data.native_global_storage_end) {
+            checkPotentialPtr(*(void**)curr, tinfo);
+        }
+    }
+
+#ifdef BSQ_GC_CHECK_ENABLED
+    if(tinfo.disable_stack_refs_for_tests) {
+        return;
+    }
+#endif
+    
     tinfo.loadNativeRootSet();
 
     for(size_t i = 0; i < tinfo.native_stack_count; i++) {

--- a/src/runtime/memory/gc.cpp
+++ b/src/runtime/memory/gc.cpp
@@ -203,9 +203,10 @@ void walkStack(BSQMemoryTheadLocalInfo& tinfo) noexcept
 {
     //Process global data (TODO -- later have flag to disable this after it is fixed as immortal)
     if(GlobalDataStorage::g_global_data.native_global_storage != nullptr) {
-        void* curr = GlobalDataStorage::g_global_data.native_global_storage;
+        void** curr = GlobalDataStorage::g_global_data.native_global_storage;
         while(curr < GlobalDataStorage::g_global_data.native_global_storage_end) {
-            checkPotentialPtr(*(void**)curr, tinfo);
+            checkPotentialPtr(*curr, tinfo);
+            curr++;
         }
     }
 

--- a/src/runtime/memory/threadinfo.h
+++ b/src/runtime/memory/threadinfo.h
@@ -68,6 +68,10 @@ struct BSQMemoryTheadLocalInfo
 
     size_t max_decrement_count;
 
+#ifdef BSQ_GC_CHECK_ENABLED
+    bool disable_stack_refs_for_tests = false;
+#endif
+
     BSQMemoryTheadLocalInfo() noexcept : tl_id(0), g_gcallocs(nullptr), native_stack_base(nullptr), native_stack_count(0), native_stack_contents(nullptr), roots_count(0), roots(nullptr), old_roots_count(0), old_roots(nullptr), forward_table_index(0), forward_table(nullptr), pending_roots(), visit_stack(), pending_young(), pending_decs(), max_decrement_count(BSQ_INITIAL_MAX_DECREMENT_COUNT) { }
 
     inline GCAllocator* getAllocatorForPageSize(PageInfo* page) noexcept {

--- a/src/runtime/support/pagetable.h
+++ b/src/runtime/support/pagetable.h
@@ -55,6 +55,10 @@ public:
     }
 
     bool pagetable_query(void* addr) const noexcept {
+        if(this->pagetable_root == nullptr) {
+            return false;
+        }
+        
         uintptr_t address = (uintptr_t)addr;
         uintptr_t index1 = (address >> LEVEL1_SHIFT) & LEVEL_MASK;  // Bits 47-36
         uintptr_t index2 = (address >> LEVEL2_SHIFT) & LEVEL_MASK;  // Bits 35-24

--- a/test/memory/memex.cpp
+++ b/test/memory/memex.cpp
@@ -45,9 +45,45 @@ std::string printlist(ListNodeValue* ll) {
     return rr + "null";
 }
 
+// int main(int argc, char** argv) {
+//     INIT_LOCKS();
+//     GlobalDataStorage::g_global_data.initialize(0, nullptr);
+//
+//     InitBSQMemoryTheadLocalInfo();
+//
+//     GCAllocator* allocs[1] = { &alloc2 };
+//     gtl_info.initializeGC<1>(allocs);
+//
+//     ListNodeValue* l1 = makeList(2, 5); //stays live
+//     makeList(3, 0); //dies
+//     auto p1start = printlist(l1);
+//
+//     collect();
+//     ListNodeValue* l2 = makeList(3, 10); //stays live
+//     auto p2start = printlist(l2);
+//     collect();
+//
+//     makeList(3, 0); //dies
+//    
+//     auto p1end = printlist(l1);
+//     assert(p1start == p1end);
+//
+//     auto p2end = printlist(l2);
+//     assert(p2start == p2end);
+//
+//     l1 = nullptr;
+//     l2 = nullptr;
+//
+//     collect();
+//
+//     return 0;
+// }
+
+void* garray[3] = {nullptr, nullptr, nullptr};
+
 int main(int argc, char** argv) {
     INIT_LOCKS();
-    GlobalDataStorage::g_global_data.initialize(0, nullptr);
+    GlobalDataStorage::g_global_data.initialize(sizeof(garray), garray);
 
     InitBSQMemoryTheadLocalInfo();
 
@@ -55,6 +91,7 @@ int main(int argc, char** argv) {
     gtl_info.initializeGC<1>(allocs);
 
     ListNodeValue* l1 = makeList(2, 5); //stays live
+    garray[0] = l1;
     makeList(3, 0); //dies
     auto p1start = printlist(l1);
 
@@ -64,17 +101,17 @@ int main(int argc, char** argv) {
     collect();
 
     makeList(3, 0); //dies
-    
+   
     auto p1end = printlist(l1);
     assert(p1start == p1end);
 
     auto p2end = printlist(l2);
     assert(p2start == p2end);
 
-    l1 = nullptr;
-    l2 = nullptr;
+    gtl_info.disable_stack_refs_for_tests = true;
 
     collect();
 
     return 0;
 }
+

--- a/test/memory/memex.cpp
+++ b/test/memory/memex.cpp
@@ -46,6 +46,9 @@ std::string printlist(ListNodeValue* ll) {
 }
 
 int main(int argc, char** argv) {
+    INIT_LOCKS();
+    GlobalDataStorage::g_global_data.initialize(0, nullptr);
+
     InitBSQMemoryTheadLocalInfo();
 
     GCAllocator* allocs[1] = { &alloc2 };


### PR DESCRIPTION
- Add a globals section that is treated like the stack roots. Allows is to place global data that may contain pointers in this segment and have it GC tracked. Also means if the GC runs while we are still initializing parts that is ok.
- Key notes about needing to be single threaded and a special scoped mark are in the code.
- Also this will be useful for debugging. I added a flag to disable stack-walking and only use the globals array. So we can precisely adjust which roots are seen and even deterministically control pointers into interiors of objects. 
