### PR TITLE
03 11 todos

### DIFF
--- a/src/runtime/common.h
+++ b/src/runtime/common.h
@@ -156,4 +156,4 @@ static_assert(sizeof(MetaData) == 8, "MetaData size is not 8 bytes");
 #define GC_CLEAR_YOUNG_MARK(META) { (META)->isyoung = false; }
 #define GC_CLEAR_ROOT_MARK(META) { (META)->ismarked = false; (META)->isroot = false; }
 
-#define GC_SHOULD_FREE_LIST_ADD(META) (!(META)->isalloc)
+#define GC_SHOULD_FREE_LIST_ADD(META) (!(META)->isalloc || !(META)->ismarked)

--- a/src/runtime/common.h
+++ b/src/runtime/common.h
@@ -156,4 +156,5 @@ static_assert(sizeof(MetaData) == 8, "MetaData size is not 8 bytes");
 #define GC_CLEAR_YOUNG_MARK(META) { (META)->isyoung = false; }
 #define GC_CLEAR_ROOT_MARK(META) { (META)->ismarked = false; (META)->isroot = false; }
 
-#define GC_SHOULD_FREE_LIST_ADD(META) (!(META)->isalloc || !(META)->ismarked)
+#define GC_SHOULD_FREE_LIST_ADD(META) (!(META)->isalloc || (!(META)->ismarked && !(META)->isroot))
+

--- a/src/runtime/memory/allocator.cpp
+++ b/src/runtime/memory/allocator.cpp
@@ -83,7 +83,6 @@ PageInfo* GlobalPageGCManager::allocateFreshPage(uint16_t entrysize, uint16_t re
 
 void GCAllocator::processPage(PageInfo* p) noexcept
 {
-    float old_util = p->approx_utilization;
     float n_util = CALC_APPROX_UTILIZATION(p);
     p->approx_utilization = n_util;
     int bucket_index = 0;
@@ -135,6 +134,93 @@ void GCAllocator::processCollectorPages() noexcept
     }
     this->pendinggc_pages = nullptr;
 }
+
+//TODO: Rework these very funky canary check functions !!!
+
+/*
+//Following 3 methods verify integrity of canaries
+bool verifyCanariesInBlock(char* block, uint16_t entry_size)
+{
+    uint64_t* pre_canary = (uint64_t*)(block);
+    uint64_t* post_canary = (uint64_t*)(block + ALLOC_DEBUG_CANARY_SIZE + sizeof(MetaData) + entry_size);
+
+    debug_print("[CANARY_CHECK] Verifying canaries for block at %p\n", block);
+    debug_print("\tPre-canary value: %lx\n", *pre_canary);
+    debug_print("\tPost-canary value: %lx\n", *post_canary);
+
+    if (*pre_canary != ALLOC_DEBUG_CANARY_VALUE || *post_canary != ALLOC_DEBUG_CANARY_VALUE)
+    {
+        debug_print("[ERROR] Canary corruption detected at block %p\n", block);
+        return false;
+    }
+    return true;
+}
+
+void verifyCanariesInPage(PageInfo* page)
+{
+    FreeListEntry* list = page->freelist;
+    uint16_t alloced_blocks = 0;
+    uint16_t free_blocks = 0;
+
+    debug_print("[CANARY_CHECK] Verifying canaries for page at %p\n", page);
+
+    for (uint16_t i = 0; i < page->entrycount; i++) {
+        char* block_address = PAGE_MASK_EXTRACT_DATA(list) + (i * REAL_ENTRY_SIZE(page->entrysize));
+        debug_print("\tChecking block %d at address %p\n", i, block_address);
+        MetaData* metadata = (MetaData*)(block_address + ALLOC_DEBUG_CANARY_SIZE);
+        debug_print("\tBlock %d metadata state: isalloc=%d\n", i, metadata->isalloc);
+
+        if (metadata->isalloc) {
+            debug_print("\tAllocated block detected, verifying canaries...\n");
+            alloced_blocks++;
+            assert(verifyCanariesInBlock(block_address, page->entrysize));
+        }
+    }
+    debug_print("\n");
+
+    debug_print("[CANARY_CHECK] Verifying freelist for page at %p\n", page);
+    while(list){
+        debug_print("\tChecking freelist block at %p\n", (void*)list);
+        MetaData* metadata = (MetaData*)((char*)list + ALLOC_DEBUG_CANARY_SIZE);
+        debug_print("\tFreelist block metadata state: isalloc=%d\n", metadata->isalloc);
+
+        if(metadata->isalloc){
+            debug_print("[ERROR] Block in free list was allocated at %p\n", list);
+            assert(0);
+        }
+        free_blocks++;
+        list = list->next;
+    }   
+
+    // Make sure no blocks are lost
+    assert((free_blocks + alloced_blocks) == page->entrycount);
+
+    debug_print("\n");
+}
+
+void verifyAllCanaries()
+{
+    for(int i = 0; i < NUM_BINS; i++) {
+        AllocatorBin* bin = getBinForSize(8 * (1 << i));
+        PageInfo* alloc_page = bin->alloc_page;
+        PageInfo* evac_page = bin->evac_page;
+
+        debug_print("[CANARY_CHECK] Verifying all pages in bin\n");
+
+        while (alloc_page) {
+            debug_print("[CANARY_CHECK] Verifying canaries in alloc page at %p\n", alloc_page);
+            verifyCanariesInPage(alloc_page);
+            alloc_page = alloc_page->next;
+        }
+
+        while (evac_page) {
+            debug_print("[CANARY_CHECK] Verifying canaries in evac page at %p\n", evac_page);
+            verifyCanariesInPage(evac_page);
+            evac_page = evac_page->next;
+        }
+    }
+}
+*/
 
 //TODO: Rework these very funky canary check functions !!!
 

--- a/src/runtime/memory/allocator.cpp
+++ b/src/runtime/memory/allocator.cpp
@@ -83,7 +83,6 @@ PageInfo* GlobalPageGCManager::allocateFreshPage(uint16_t entrysize, uint16_t re
 
 void GCAllocator::processPage(PageInfo* p) noexcept
 {
-    //float old_util = p->approx_utilization;
     float n_util = CALC_APPROX_UTILIZATION(p);
     p->approx_utilization = n_util;
     int bucket_index = 0;
@@ -99,6 +98,11 @@ void GCAllocator::processPage(PageInfo* p) noexcept
     else if(IS_FULL(n_util)) {
         p->next = this->filled_pages;
         filled_pages = p;
+    }
+    else {
+        GC_MEM_LOCK_ACQUIRE();
+        GlobalPageGCManager::g_gc_page_manager.addNewPage(p);
+        GC_MEM_LOCK_RELEASE();
     }
 }
 

--- a/src/runtime/memory/allocator.cpp
+++ b/src/runtime/memory/allocator.cpp
@@ -83,6 +83,7 @@ PageInfo* GlobalPageGCManager::allocateFreshPage(uint16_t entrysize, uint16_t re
 
 void GCAllocator::processPage(PageInfo* p) noexcept
 {
+    float old_util = p->approx_utilization;
     float n_util = CALC_APPROX_UTILIZATION(p);
     p->approx_utilization = n_util;
     int bucket_index = 0;

--- a/src/runtime/memory/allocator.h
+++ b/src/runtime/memory/allocator.h
@@ -173,7 +173,9 @@ public:
 
 #define IS_LOW_UTIL(U) (U >= 0.01f && U < 0.60f)
 #define IS_HIGH_UTIL(U) (U > 0.60f && U <= 0.90f)
-#define IS_FULL(U) (U > 0.90f)
+
+//<=1.0f is very crucial here because new pages start at 100.0f, wihout we just reprocess them until OOM
+#define IS_FULL(U) (U > 0.90f && U <= 1.0f)
 
 //Find proper bucket based on increments of 0.05f
 #define GET_BUCKET_INDEX(U, N, I)                   \

--- a/src/runtime/memory/allocator.h
+++ b/src/runtime/memory/allocator.h
@@ -415,3 +415,83 @@ public:
     //process all the pending gc pages, the current alloc page, and evac page -- reset for next round
     void processCollectorPages() noexcept;
 };
+
+
+/*
+   inline PageInfo* getSuccessor(PageInfo* p) {
+        p = p->right;
+        while(p != nullptr && p->left != nullptr) {
+            p = p->left;
+        }
+        return p;
+    }
+
+    inline PageInfo* deletePageFromBucket(PageInfo* root, PageInfo* old_page)
+    {
+        float old_util = old_page->approx_utilization;
+
+        if(root == nullptr) {
+            return root;
+        }
+
+        if(root->approx_utilization > old_util && root != old_page) {
+            root->left = deletePageFromBucket(root->left, old_page);
+        }
+        else if (root->approx_utilization < old_util && root != old_page) {
+            root->right = deletePageFromBucket(root->right, old_page);
+        }
+        else {
+            if(root->left == nullptr) {
+                PageInfo* tmp = root->right;
+                root = nullptr;
+                return tmp;
+            }
+            if(root->right == nullptr) {
+                PageInfo* tmp = root->left;
+                root = nullptr;
+                return tmp;
+            }
+
+            PageInfo* successor = getSuccessor(root);
+            root->approx_utilization = successor->approx_utilization;
+            root->right = deletePageFromBucket(root->right, successor);
+        }
+        return root;
+    }
+
+    inline PageInfo* getSuccessor(PageInfo* p) {
+        p = p->right;
+        while(p != nullptr && p->left != nullptr) {
+            p = p->left;
+        }
+        return p;
+    }
+
+    //used in case where a page's utilization changed and it isnt being grabbed for evac/alloc
+    void deleteOldPage(PageInfo* p) {
+        int bucket_index = 0;
+        float old_util = p->approx_utilization;
+
+        if(IS_LOW_UTIL(old_util)) {
+            GET_BUCKET_INDEX(old_util, NUM_LOW_UTIL_BUCKETS, bucket_index);
+            this->deletePageFromBucket(
+                this->low_utilization_buckets[bucket_index], p);        
+        }
+        else if(IS_HIGH_UTIL(old_util)) {
+            GET_BUCKET_INDEX(old_util, NUM_HIGH_UTIL_BUCKETS, bucket_index);
+            this->deletePageFromBucket(
+                this->high_utilization_buckets[bucket_index], p);
+        }
+        else {
+            PageInfo* cur = this->filled_pages;
+            PageInfo* prev = nullptr;
+            while(cur != nullptr && cur != p) {
+                prev = cur;
+                cur = cur->next;
+            }
+
+            prev->next = cur->next;
+            p->next = nullptr;
+        }
+    }
+*/

--- a/src/runtime/memory/allocator.h
+++ b/src/runtime/memory/allocator.h
@@ -352,6 +352,23 @@ public:
         return this->allocsize;
     }
 
+    //simple check to see if a page is in alloc/evac/pendinggc pages
+    bool checkNonAllocOrGCPage(PageInfo* p) {
+        if(p == alloc_page || p == evac_page) {
+            return false;
+        }
+
+        PageInfo* cur = pendinggc_pages;
+        while(cur != nullptr) {
+            if(cur == p) {
+                return false;
+            }
+            cur = cur->next;
+        }
+
+        return true;
+    }
+
     inline void* allocate(TypeInfoBase* type)
     {
         assert(type->type_size == this->allocsize);

--- a/src/runtime/memory/gc.cpp
+++ b/src/runtime/memory/gc.cpp
@@ -2,6 +2,7 @@
 #include "allocator.h"
 #include "gc.h"
 #include "../support/qsort.h"
+#include "threadinfo.h"
 
 // Used to determine if a pointer points into the data segment of an object
 #define POINTS_TO_DATA_SEG(P) P >= (void*)PAGE_FIND_OBJ_BASE(P) && P < (void*)((char*)PAGE_FIND_OBJ_BASE(P) + PAGE_MASK_EXTRACT_PINFO(P)->entrysize)

--- a/src/runtime/memory/gc.cpp
+++ b/src/runtime/memory/gc.cpp
@@ -120,6 +120,9 @@ void processDecrements(BSQMemoryTheadLocalInfo& tinfo) noexcept
         //everything alive?
         //
 
+        //this is HORRIBY innefficient
+        //TODO: FIX THIS PLZ!!!! And do the stuff i wrote above prob
+        objects_page->rebuild();
     }
 
     GC_REFCT_LOCK_RELEASE();
@@ -189,7 +192,8 @@ void processMarkedYoungObjects(BSQMemoryTheadLocalInfo& tinfo) noexcept
 
 void checkPotentialPtr(void* addr, BSQMemoryTheadLocalInfo& tinfo) noexcept
 {
-    if(GlobalPageGCManager::g_gc_page_manager.pagetable_query(addr)) {
+    if(GlobalPageGCManager::g_gc_page_manager.pagetable_query(addr)
+        && ((uintptr_t)addr & 0xFFF) != 0) {
         MetaData* meta = PageInfo::getObjectMetadataAligned(addr);
         void* obj = (void*)((uint8_t*)meta + sizeof(MetaData));
         

--- a/src/runtime/memory/gc.cpp
+++ b/src/runtime/memory/gc.cpp
@@ -17,9 +17,6 @@ void reprocessPageInfo(PageInfo* page, BSQMemoryTheadLocalInfo& tinfo) noexcept
 {
     //This should not be called on pages that are (1) active allocators or evacuators or (2) pending collection pages
 
-    //
-    //TODO: we need to reprocess the page info here and get it in the correct list of pages
-    //
     GCAllocator* gcalloc = tinfo.getAllocatorForPageSize(page);
     if(gcalloc->checkNonAllocOrGCPage(page)) {
         gcalloc->deleteOldPage(page);
@@ -73,7 +70,8 @@ bool pageNeedsMoved(float old_util, float new_util)
     else if(old_util >= 0.90f && new_util < 0.90f) {
         return true;
     }
-    else if((old_util - new_util) > 0.05f || (new_util - old_util) > 0.05f) {
+    else if(((old_util - new_util) > 0.05f || (new_util - old_util) > 0.05f) 
+        && old_util < 0.90f && new_util < 0.90f) {
         return true;
     }
     else{
@@ -127,11 +125,8 @@ void processDecrements(BSQMemoryTheadLocalInfo& tinfo) noexcept
         GC_IS_ALLOCATED(obj) = false;
 
         objects_page->freecount++;
-        //
-        //TODO: once we have heapified the lists we can compare the computed capcity with the capcity in the heap and (if we are over a threshold) and call reprocessPageInfo
-        //
 
-
+        //if a difference in utilization (>0.05f) or drop from filled pages detected reprocess
         if(pageNeedsMoved(objects_page->approx_utilization, CALC_APPROX_UTILIZATION(objects_page))) {
             reprocessPageInfo(objects_page, tinfo);
         }

--- a/src/runtime/memory/gc.cpp
+++ b/src/runtime/memory/gc.cpp
@@ -21,10 +21,6 @@ void reprocessPageInfo(PageInfo* page, BSQMemoryTheadLocalInfo& tinfo) noexcept
     //TODO: we need to reprocess the page info here and get it in the correct list of pages
     //
 
-    GCAllocator* gcalloc = tinfo.getAllocatorForPageSize(page);
-    if(gcalloc->checkNonAllocOrGCPage(page)) {
-        gcalloc->processPage(page);
-    }
 }
 
 void computeDeadRootsForDecrement(BSQMemoryTheadLocalInfo& tinfo) noexcept
@@ -115,15 +111,15 @@ void processDecrements(BSQMemoryTheadLocalInfo& tinfo) noexcept
         //
 
         //
-        //Looks like we will also need to do a more proper bst deletion here since in this case
-        //it is possible for our page to exist in the bst already
+        //Need to think more about what is actually necessary here - 
+        //for some reason my brain just cant quite figure out what
+        //exactly i need to do. it appears removing from old location
+        //in one of our bst buckets, but idrk. also i discovered
+        //that we never actually insert a page into the global page
+        //list which is not good. something object could be keeing 
+        //everything alive?
         //
 
-        //not totally confident in this float comparisons 
-        float new_util = CALC_APPROX_UTILIZATION(objects_page);
-        if(new_util > objects_page->approx_utilization || new_util < objects_page->approx_utilization){
-            reprocessPageInfo(objects_page, tinfo);
-        }
     }
 
     GC_REFCT_LOCK_RELEASE();

--- a/src/runtime/memory/gc.h
+++ b/src/runtime/memory/gc.h
@@ -1,7 +1,5 @@
 #pragma once
 
-#include "threadinfo.h"
-
 #ifdef GC_INVARIANTS
 #define GC_INVARIANT_CHECK(x) assert(x)
 #else

--- a/src/runtime/support/pagetable.h
+++ b/src/runtime/support/pagetable.h
@@ -8,13 +8,23 @@ class PageTableInUseInfo
 private:
     void** pagetable_root;
 
+    //
+    //Original implementation designed for 12 bits per level fails
+    //due to the fact that our pages being 4096 bytes, meaning since
+    //each block stores a void* we can have up to 4096/8 = 512 entries
+    //so in order to utilize space most effectively we can have
+    //log2(512) = 9 bits per level
+    //
+    
     constexpr static uintptr_t PAGETABLE_LEVELS = 4;
-    constexpr static uintptr_t BITS_PER_LEVEL = 12;
-
-    constexpr static uintptr_t LEVEL1_SHIFT = 36;
-    constexpr static uintptr_t LEVEL2_SHIFT = 24;
-    constexpr static uintptr_t LEVEL3_SHIFT = 12;
-    constexpr static uintptr_t LEVEL_MASK = 0xFFF;
+    constexpr static uintptr_t BITS_PER_LEVEL = 9; 
+    
+    constexpr static uintptr_t LEVEL1_SHIFT = 39; 
+    constexpr static uintptr_t LEVEL2_SHIFT = 30; 
+    constexpr static uintptr_t LEVEL3_SHIFT = 21; 
+    constexpr static uintptr_t LEVEL4_SHIFT = 12; 
+    constexpr static uintptr_t LEVEL_MASK = 0x1FF; 
+    constexpr static uintptr_t PAGE_MASK = 0xFFF;
     constexpr static uintptr_t PAGE_PRESENT = 1;
 
 public:
@@ -27,10 +37,10 @@ public:
         }
 
         uintptr_t address = (uintptr_t)addr;
-        uintptr_t index1 = (address >> LEVEL1_SHIFT) & LEVEL_MASK; // Bits 47-36
-        uintptr_t index2 = (address >> LEVEL2_SHIFT) & LEVEL_MASK; // Bits 35-24
-        uintptr_t index3 = (address >> LEVEL3_SHIFT) & LEVEL_MASK; // Bits 23-12
-        uintptr_t index4 = address & LEVEL_MASK;                   // Bits 11-0
+        uintptr_t index1 = (address >> LEVEL1_SHIFT) & LEVEL_MASK; // Bits 47-39
+        uintptr_t index2 = (address >> LEVEL2_SHIFT) & LEVEL_MASK; // Bits 38-30
+        uintptr_t index3 = (address >> LEVEL3_SHIFT) & LEVEL_MASK; // Bits 29-21
+        uintptr_t index4 = (address >> LEVEL4_SHIFT) & LEVEL_MASK; // Bits 20-12
 
         void** level1 = pagetable_root;
         if(!level1[index1]) {
@@ -60,10 +70,10 @@ public:
         }
         
         uintptr_t address = (uintptr_t)addr;
-        uintptr_t index1 = (address >> LEVEL1_SHIFT) & LEVEL_MASK;  // Bits 47-36
-        uintptr_t index2 = (address >> LEVEL2_SHIFT) & LEVEL_MASK;  // Bits 35-24
-        uintptr_t index3 = (address >> LEVEL3_SHIFT) & LEVEL_MASK;  // Bits 23-12
-        uintptr_t index4 = (address & PAGE_ADDR_MASK) & LEVEL_MASK; // Bits 11-0
+        uintptr_t index1 = (address >> LEVEL1_SHIFT) & LEVEL_MASK; // Bits 47-39
+        uintptr_t index2 = (address >> LEVEL2_SHIFT) & LEVEL_MASK; // Bits 38-30
+        uintptr_t index3 = (address >> LEVEL3_SHIFT) & LEVEL_MASK; // Bits 29-21
+        uintptr_t index4 = (address >> LEVEL4_SHIFT) & LEVEL_MASK; // Bits 20-12
 
         void** level1 = pagetable_root;
         if(!level1[index1]) {

--- a/test/memory/memex.cpp
+++ b/test/memory/memex.cpp
@@ -1,4 +1,5 @@
 #include "../../src/runtime/memory/gc.h"
+#include "../../src/runtime/memory/threadinfo.h"
 
 #include <string>
 #include <format>

--- a/test/nbody.cpp
+++ b/test/nbody.cpp
@@ -3,6 +3,7 @@
 #include <iostream>
 #include <math.h>
 #include <stdlib.h>
+#include <string.h>
 
 GCAllocator alloc1(8, REAL_ENTRY_SIZE(8), collect);
 GCAllocator alloc2(16, REAL_ENTRY_SIZE(16), collect);

--- a/test/nbody.cpp
+++ b/test/nbody.cpp
@@ -368,7 +368,7 @@ int main(int argc, char** argv)
     GCAllocator* allocs[2] = { &alloc1, &alloc2 };
     gtl_info.initializeGC<2>(allocs);
 
-    int n = 20000;
+    int n = 50000000;
     void** sys = createNBodySystem();
     double step = 0.01;
     

--- a/test/nbody.cpp
+++ b/test/nbody.cpp
@@ -1,12 +1,8 @@
 #include "../src/runtime/memory/gc.h"
+#include "../src/runtime/memory/threadinfo.h"
 #include <iostream>
 #include <math.h>
 #include <stdlib.h>
-
-//
-// Doesn't work with new cpp conversion, after some of the gc TODOs are
-// taken care of come back and run some tests here
-//
 
 GCAllocator alloc1(8, REAL_ENTRY_SIZE(8), collect);
 GCAllocator alloc2(16, REAL_ENTRY_SIZE(16), collect);
@@ -372,24 +368,20 @@ int main(int argc, char** argv)
     GCAllocator* allocs[2] = { &alloc1, &alloc2 };
     gtl_info.initializeGC<2>(allocs);
 
-    int n = 5;
+    int n = 20000;
     void** sys = createNBodySystem();
     double step = 0.01;
     
     printf("energy: %g\n", energy(sys));
 
-    /* Currently does not work for large n, fails after about 20 advances */
     for(int i = 0; i < n; i++) {
         if(i % 10 == 0) {
-            collect();
             static_bodies_index = 0;
         }
         sys = advance(sys, step);
     }
 
     gtl_info.disable_stack_refs_for_tests = true;
-
-    collect();
 
     printf("energy: %g\n", energy(sys));
 


### PR DESCRIPTION
- page table now uses 9 bits per level rather than original 12. This is due to each page in the table being able to store a max of 512 pointers to other pages (4096/8)
- cleaned up bst deletion logic a bit and made page processing more succinct
- when handing a page that is experiencing decrements, we now do a more traditional bst deletion in order to move the page to proper bucket based in approximate utilization and delete from filled pages list. Thinking about doing this iteratively rather than recursively
- also was able to run nbody and gc with 50,000,000 steps! (still need to see how efficiently this was running, took ~7 minutes)