### PR TITLE
Memstats 

### DIFF
--- a/src/runtime/memory/allocator.h
+++ b/src/runtime/memory/allocator.h
@@ -370,6 +370,11 @@ private:
 
     void allocatorRefreshEvacuationPage() noexcept
     {
+        //if our evac page is full put it on filled pages list (no need to rebuild)
+        if(this->evac_page != nullptr && this->evac_page->freecount == 0) {
+            this->evac_page->next = this->filled_pages;
+            this->filled_pages = this->evac_page;
+        }
         this->evac_page = this->getFreshPageForEvacuation();
         this->evacfreelist = this->evac_page->freelist;
     }

--- a/src/runtime/memory/allocator.h
+++ b/src/runtime/memory/allocator.h
@@ -224,14 +224,15 @@ private:
 
     inline void insertPageInBucket(PageInfo** bucket, PageInfo* new_page, float n_util, int index) 
     {                             
-        if(new_page == nullptr) {
-            assert(0);
+        if(new_page == nullptr) { //sanity check
+            assert(false);
         }
         
         PageInfo* root = bucket[index];     
         new_page->left = nullptr;
         new_page->right = nullptr;
 
+        //no root case
         if(root == nullptr) {
             bucket[index] = new_page;
             new_page->left = nullptr;
@@ -240,7 +241,6 @@ private:
             return ;
         }
     
-        //Perhaps do so just to make sure we modify the real bucket?
         PageInfo* current = root;
         while (true) {
             if (n_util < current->approx_utilization) {
@@ -264,7 +264,7 @@ private:
     }
 
     //
-    //Could perhaps be nice to make this not recursive
+    //Could be nice to make this method non-recursive, gets kinda messy through
     //
     inline void deletePageFromBucket(PageInfo* root, PageInfo* old_page)
     {
@@ -389,7 +389,7 @@ public:
         return this->allocsize;
     }
 
-    //simple check to see if a page is in alloc/evac/pendinggc pages
+    //Simple check to see if a page is in alloc/evac/pendinggc pages
     bool checkNonAllocOrGCPage(PageInfo* p) {
         if(p == alloc_page || p == evac_page) {
             return false;
@@ -406,7 +406,7 @@ public:
         return true;
     }
 
-    //used in case where a page's utilization changed and it isnt being grabbed for evac/alloc
+    //Used in case where a page's utilization changed and it isnt being grabbed for evac/alloc
     void deleteOldPage(PageInfo* p) 
     {
         int bucket_index = 0;
@@ -422,6 +422,8 @@ public:
             this->deletePageFromBucket(
                 this->high_utilization_buckets[bucket_index], p);
         }
+
+        //May want to make this traversal not O(n) worst case (sort?)
         else {
             PageInfo* cur = this->filled_pages;
             PageInfo* prev = nullptr;
@@ -475,7 +477,11 @@ public:
         return SETUP_ALLOC_LAYOUT_GET_OBJ_PTR(entry);
     }
 
+#ifdef MEM_STATS
     void updateMemStats();
+#else
+    inline void updateMemStats() {}
+#endif
 
     //Take a page (that may be in of the page sets -- or may not -- if it is a alloc or evac page) and move it to the appropriate page set
     void processPage(PageInfo* p) noexcept;

--- a/src/runtime/memory/allocator.h
+++ b/src/runtime/memory/allocator.h
@@ -464,13 +464,9 @@ public:
     
         SET_ALLOC_LAYOUT_HANDLE_CANARY(entry, type);
         SETUP_ALLOC_INITIALIZE_FRESH_META(SETUP_ALLOC_LAYOUT_GET_META_PTR(entry), type);
-    
-        increaseAllocMemStats(type->type_size);
-    
+        
         return SETUP_ALLOC_LAYOUT_GET_OBJ_PTR(entry);
     }
-
-    void increaseAllocMemStats(uint32_t size);
 
     //call at end of collection if memstats are enabled
     void updateMemStats();

--- a/src/runtime/memory/gc.cpp
+++ b/src/runtime/memory/gc.cpp
@@ -344,10 +344,12 @@ void collect() noexcept
     processDecrements(gtl_info);
     gtl_info.pending_decs.clear();
 
+    gtl_info.total_live_bytes = 0;
     for(size_t i = 0; i < BSQ_MAX_ALLOC_SLOTS; i++) {
         GCAllocator* alloc = gtl_info.g_gcallocs[i];
         if(alloc != nullptr) {
             alloc->processCollectorPages();
+            alloc->updateMemStats();
         }
     }
 

--- a/src/runtime/memory/gc.cpp
+++ b/src/runtime/memory/gc.cpp
@@ -99,8 +99,9 @@ void processDecrements(BSQMemoryTheadLocalInfo& tinfo) noexcept
         void* obj = (void**)tinfo.pending_decs.pop_front();
         deccount++;
 
-        // Skip if the object is already freed
-        if (!GC_IS_ALLOCATED(obj)) {
+        // Skip if the object is already freed or if we find a root object
+        //If this object is a root we dont want to explore its children (this deletes a subtree who is still alive)
+        if (!GC_IS_ALLOCATED(obj) || GC_IS_ROOT(obj)) {
             continue;
         }
 

--- a/src/runtime/memory/threadinfo.h
+++ b/src/runtime/memory/threadinfo.h
@@ -70,8 +70,15 @@ struct BSQMemoryTheadLocalInfo
 
     size_t max_decrement_count;
 
-    //We may want this in prod, so it'll always be visible
+    //We may want this in prod, so i'll have it always be visible
     bool disable_automatic_collections = false;
+
+#ifdef MEM_STATS
+    uint64_t num_allocs = 0;
+    uint64_t total_gc_pages = 0;
+    uint64_t total_empty_gc_pages = 0;
+    uint64_t total_live_bytes = 0; //doesnt include canary or metadata size
+#endif
 
 #ifdef BSQ_GC_CHECK_ENABLED
     bool disable_stack_refs_for_tests = false;

--- a/test/multiple_tree_basic.cpp
+++ b/test/multiple_tree_basic.cpp
@@ -84,6 +84,8 @@ int main(int argc, char **argv)
     TreeNodeValue* tree18 = makeTree(1, 4);
     TreeNodeValue* tree19 = makeTree(1, 4);
 
+    uint64_t init_total_bytes = gtl_info.total_live_bytes;
+
     assert(tree1 != nullptr);
     assert(tree2 != nullptr);
     assert(tree3 != nullptr);
@@ -165,6 +167,8 @@ int main(int argc, char **argv)
     assert(tree17_initial_state == tree17_final_state);
     assert(tree18_initial_state == tree18_final_state);
     assert(tree19_initial_state == tree19_final_state);
+
+    assert(init_total_bytes == gtl_info.total_live_bytes);
 
     return 0;
 }

--- a/test/multiple_tree_basic.cpp
+++ b/test/multiple_tree_basic.cpp
@@ -84,7 +84,8 @@ int main(int argc, char **argv)
     TreeNodeValue* tree18 = makeTree(1, 4);
     TreeNodeValue* tree19 = makeTree(1, 4);
 
-    uint64_t init_total_bytes = gtl_info.total_live_bytes;
+    //we run 19 trees, each create 3 nodes of size 24 bytes
+    uint64_t init_total_bytes = 19 * (24 * 3);
 
     assert(tree1 != nullptr);
     assert(tree2 != nullptr);
@@ -168,7 +169,8 @@ int main(int argc, char **argv)
     assert(tree18_initial_state == tree18_final_state);
     assert(tree19_initial_state == tree19_final_state);
 
-    assert(init_total_bytes == gtl_info.total_live_bytes);
+    uint64_t final = gtl_info.total_live_bytes;
+    assert(init_total_bytes == final);
 
     return 0;
 }

--- a/test/nbody.cpp
+++ b/test/nbody.cpp
@@ -300,6 +300,7 @@ int main(int argc, char** argv)
 
     InitBSQMemoryTheadLocalInfo();
     gtl_info.disable_automatic_collections = true;
+    gtl_info.disable_stack_refs_for_tests = true;
 
     GCAllocator* allocs[3] = { &alloc3, &alloc4, &alloc5 };
     gtl_info.initializeGC<3>(allocs);

--- a/test/tree_basic.cpp
+++ b/test/tree_basic.cpp
@@ -67,6 +67,8 @@ int main(int argc, char** argv) {
 
     TreeNodeValue* t1 = makeTree(1, 4);
 
+    uint64_t init_total_bytes = gtl_info.total_live_bytes;
+
     auto t1_start = printtree(t1);
     collect();
 
@@ -79,6 +81,8 @@ int main(int argc, char** argv) {
 
     assert(t1_end == t1_end_end);
     assert(t1_start == t1_end_end);
+
+    assert(init_total_bytes == gtl_info.total_live_bytes);
 
     return 0;
 }

--- a/test/tree_basic.cpp
+++ b/test/tree_basic.cpp
@@ -67,7 +67,8 @@ int main(int argc, char** argv) {
 
     TreeNodeValue* t1 = makeTree(1, 4);
 
-    uint64_t init_total_bytes = gtl_info.total_live_bytes;
+    //one tree where all 3 nodes are 24 bytes
+    uint64_t init_total_bytes = 3 * 24;
 
     auto t1_start = printtree(t1);
     collect();

--- a/test/tree_basic.cpp
+++ b/test/tree_basic.cpp
@@ -66,6 +66,7 @@ int main(int argc, char** argv) {
     gtl_info.initializeGC<1>(allocs);
 
     TreeNodeValue* t1 = makeTree(1, 4);
+    garray[0] = t1;
 
     //one tree where all 3 nodes are 24 bytes
     uint64_t init_total_bytes = 3 * 24;
@@ -84,6 +85,12 @@ int main(int argc, char** argv) {
     assert(t1_start == t1_end_end);
 
     assert(init_total_bytes == gtl_info.total_live_bytes);
+
+    gtl_info.disable_stack_refs_for_tests = true;
+    garray[0] = nullptr;
+    collect();
+
+    assert(gtl_info.total_live_bytes == 0);
 
     return 0;
 }

--- a/test/tree_deep.cpp
+++ b/test/tree_deep.cpp
@@ -92,7 +92,6 @@ int main(int argc, char** argv) {
 
     InitBSQMemoryTheadLocalInfo();
     gtl_info.disable_automatic_collections = true;
-    gtl_info.disable_stack_refs_for_tests = true;
 
     GCAllocator* allocs[1] = { &alloc3 };
     gtl_info.initializeGC<1>(allocs);
@@ -112,6 +111,12 @@ int main(int argc, char** argv) {
 
     uint64_t final = gtl_info.total_live_bytes;
     assert(init_total_bytes == final);
+
+    gtl_info.disable_stack_refs_for_tests = true;
+    garray[0] = nullptr;
+    collect();
+
+    assert(gtl_info.total_live_bytes == 0);
 
     return 0;
 }

--- a/test/tree_deep.cpp
+++ b/test/tree_deep.cpp
@@ -80,6 +80,7 @@ TreeNodeValue* garray[3] = {nullptr, nullptr, nullptr};
 
 //
 //Full tree of varrying depths
+//A possible improvement could be making tree for each depth up to a certain threshold (say n=14)
 //
 int main(int argc, char** argv) {
     INIT_LOCKS();
@@ -93,7 +94,9 @@ int main(int argc, char** argv) {
     //Force this node to be root, may not be necessary but works fine
     TreeNodeValue* tree_root = AllocType(TreeNodeValue, alloc3, &TreeNodeType);
     garray[0] = tree_root;
-    makeTree(tree_root, 20, 4);
+    makeTree(tree_root, 13, 4);
+
+    uint64_t init_total_bytes = gtl_info.total_live_bytes;
 
     auto t1_start = printtree(tree_root);
     collect();
@@ -101,5 +104,7 @@ int main(int argc, char** argv) {
     auto t1_end = printtree(tree_root);
 
     assert(t1_start == t1_end);
+    assert(init_total_bytes == gtl_info.total_live_bytes);
+
     return 0;
 }

--- a/test/tree_deep.cpp
+++ b/test/tree_deep.cpp
@@ -4,7 +4,6 @@
 #include <string>
 #include <format>
 #include <stack>
-#include <cmath>
 
 //had to add extra slot to represent val field
 struct TypeInfoBase TreeNodeType = {
@@ -28,7 +27,7 @@ GCAllocator alloc3(24, REAL_ENTRY_SIZE(24), collect);
 //a collection
 //
 TreeNodeValue* makeTree(int64_t depth, int64_t val) {
-    if (depth < 1) {
+    if (depth < 0) {
         return nullptr; 
     }
 
@@ -93,6 +92,7 @@ int main(int argc, char** argv) {
 
     InitBSQMemoryTheadLocalInfo();
     gtl_info.disable_automatic_collections = true;
+    gtl_info.disable_stack_refs_for_tests = true;
 
     GCAllocator* allocs[1] = { &alloc3 };
     gtl_info.initializeGC<1>(allocs);
@@ -101,11 +101,11 @@ int main(int argc, char** argv) {
     TreeNodeValue* tree_root = makeTree(depth, 4);
     garray[0] = tree_root;
 
-    uint64_t init_total_bytes = (uint64_t)(pow(2.0, depth + 1) * TreeNodeType.type_size);
+    uint64_t init_total_bytes = ((1 << (depth + 1)) - 1) * TreeNodeType.type_size;
 
     auto t1_start = printtree(tree_root);
     collect();
-
+    
     auto t1_end = printtree(tree_root);
 
     assert(t1_start == t1_end);

--- a/test/tree_multiple_size.cpp
+++ b/test/tree_multiple_size.cpp
@@ -254,5 +254,11 @@ int main(int argc, char** argv) {
     uint64_t final = gtl_info.total_live_bytes;
     assert(init_total_bytes == final);
 
+    gtl_info.disable_stack_refs_for_tests = true;
+    garray[0] = nullptr;
+    collect();
+
+    assert(gtl_info.total_live_bytes == 0);
+
     return 0;
 }

--- a/test/tree_multiple_size.cpp
+++ b/test/tree_multiple_size.cpp
@@ -219,11 +219,15 @@ int main(int argc, char** argv) {
     void* t = makeTree(1, 5, 0);
     garray[0] = t;
 
+    uint64_t init_total_bytes = gtl_info.total_live_bytes;
+
     auto t1_start = printtree(t);
     collect();
 
     auto t1_end = printtree(t);
 
     assert(t1_start == t1_end);
+    assert(init_total_bytes == gtl_info.total_live_bytes);
+
     return 0;
 }

--- a/test/tree_two_root.cpp
+++ b/test/tree_two_root.cpp
@@ -77,7 +77,8 @@ int main(int argc, char **argv)
     GCAllocator* allocs[1] = { &alloc4 };
     gtl_info.initializeGC<1>(allocs);
 
-    TreeNodeValue* root1 = makeSharedTree(10, 2);
+    int depth = 10;
+    TreeNodeValue* root1 = makeSharedTree(depth, 2);
     garray[0] = root1;
     TreeNodeValue* root2 = AllocType(TreeNodeValue, alloc4, &TreeNode3Type);
     root2->val = 2; //we started with 2 as value for root1
@@ -105,6 +106,19 @@ int main(int argc, char **argv)
     //We should only lose one node for root1
     uint64_t final = gtl_info.total_live_bytes;
     assert(init_total_bytes == (final + TreeNode3Type.type_size));
+
+    garray[0] = nullptr;
+
+    //We have a pretty big tree here, so we need lots of collections to clear out pending decs
+    collect();
+    collect();
+    collect();
+    collect();
+    collect();
+    collect();
+    collect();
+
+    assert(gtl_info.total_live_bytes == 0);
 
     return 0;
 }

--- a/test/tree_two_root.cpp
+++ b/test/tree_two_root.cpp
@@ -64,6 +64,8 @@ void* garray[3] = {nullptr, nullptr, nullptr};
 //No objects should be deleted since they still have one root ref
 //after dropping the second.
 //
+
+//TODO: Calculate memstats for total bytes when rebuilding a page
 int main(int argc, char **argv)
 {
     INIT_LOCKS();
@@ -88,6 +90,8 @@ int main(int argc, char **argv)
 
     auto root1_init = printtree(root1);
 
+    uint64_t init_total_bytes = gtl_info.total_live_bytes;
+
     collect();
 
     //drop root1
@@ -98,6 +102,10 @@ int main(int argc, char **argv)
     auto root2_final = printtree(root2);
 
     assert(root1_init == root2_final);
+
+    //We should only lose one node for root1
+    uint64_t final = gtl_info.total_live_bytes;
+    assert(init_total_bytes == (final + TreeNode3Type.type_size));
 
     return 0;
 }

--- a/test/tree_two_root.cpp
+++ b/test/tree_two_root.cpp
@@ -65,7 +65,6 @@ void* garray[3] = {nullptr, nullptr, nullptr};
 //after dropping the second.
 //
 
-//TODO: Calculate memstats for total bytes when rebuilding a page
 int main(int argc, char **argv)
 {
     INIT_LOCKS();
@@ -90,18 +89,18 @@ int main(int argc, char **argv)
 
     auto root1_init = printtree(root1);
 
-    uint64_t init_total_bytes = gtl_info.total_live_bytes;
-
     collect();
 
-    //drop root1
-    root1 = nullptr;
+    uint64_t init_total_bytes = gtl_info.total_live_bytes;
+
+    //drop root2
+    garray[1] = nullptr;
     
     collect();
 
-    auto root2_final = printtree(root2);
+    auto root1_final = printtree(root1);
 
-    assert(root1_init == root2_final);
+    assert(root1_init == root1_final);
 
     //We should only lose one node for root1
     uint64_t final = gtl_info.total_live_bytes;

--- a/test/tree_wide.cpp
+++ b/test/tree_wide.cpp
@@ -155,6 +155,8 @@ int main(int argc, char **argv)
     TreeNodeValue* root = makeTree(2, 2);
     TreeNodeValue* root0 = makeTree(2, 2);
 
+    uint64_t init_total_bytes = gtl_info.total_live_bytes;
+
     auto root_init = printtree(root);
     auto root0_init = printtree(root0);
 
@@ -164,6 +166,7 @@ int main(int argc, char **argv)
     auto root0_final = printtree(root0);
 
     assert((root_init == root_final) == (root0_init == root0_final));
+    assert(init_total_bytes == gtl_info.total_live_bytes);
     
     return 0;
 }

--- a/test/tree_wide.cpp
+++ b/test/tree_wide.cpp
@@ -174,7 +174,6 @@ int main(int argc, char **argv)
 
     garray[0] = nullptr;
     garray[1] = nullptr;
-
     collect();
     
     assert(gtl_info.total_live_bytes == 0);

--- a/test/tree_wide_drop_root.cpp
+++ b/test/tree_wide_drop_root.cpp
@@ -186,7 +186,6 @@ int main(int argc, char **argv)
     assert(true_final_bytes == expected_final_bytes);
 
     garray[1] = nullptr;
-    
     collect();
 
     assert(gtl_info.total_live_bytes == 0);

--- a/test/tree_wide_drop_root.cpp
+++ b/test/tree_wide_drop_root.cpp
@@ -162,6 +162,7 @@ int main(int argc, char **argv)
     garray[1] = root->n15; //stays alive
 
     int n15_init_val = root->n15->val;
+    uint64_t init_total_bytes = gtl_info.total_live_bytes;
 
     auto n15_init = printtree(garray[1]);
 
@@ -176,6 +177,7 @@ int main(int argc, char **argv)
     assert(garray[1] != nullptr);
     assert(n15_final == n15_init);
     assert(garray[1]->val == n15_init_val);
+    assert(init_total_bytes == (gtl_info.total_live_bytes - 248));
 
     return 0;
 }

--- a/test/tree_wide_drop_root.cpp
+++ b/test/tree_wide_drop_root.cpp
@@ -9,7 +9,7 @@ struct TypeInfoBase TreeNode30Type = {
     .type_id = 1,
     .type_size = 248,
     .slot_size = 31,
-    .ptr_mask = "11111111111111111111111111110",  
+    .ptr_mask = "1111111111111111111111111111110",  
     .typekey = "TreeNode30Type"
 };
 
@@ -157,18 +157,20 @@ int main(int argc, char **argv)
     GCAllocator* allocs[1] = { &alloc248 };
     gtl_info.initializeGC<1>(allocs);
 
-    TreeNodeValue* root = makeTree(2, 2);
+    int depth = 2;
+    TreeNodeValue* root = makeTree(depth, 2);
     garray[0] = root;
     garray[1] = root->n15; //stays alive
 
     int n15_init_val = root->n15->val;
-    uint64_t init_total_bytes = gtl_info.total_live_bytes;
-
     auto n15_init = printtree(garray[1]);
 
     collect();
 
-    root = nullptr;
+    uint64_t init_total_bytes = (1 + 30 + 30*30) * TreeNode30Type.type_size;
+    assert(gtl_info.total_live_bytes == init_total_bytes);
+
+    garray[0] = nullptr;
 
     collect();
 
@@ -177,7 +179,17 @@ int main(int argc, char **argv)
     assert(garray[1] != nullptr);
     assert(n15_final == n15_init);
     assert(garray[1]->val == n15_init_val);
-    assert(init_total_bytes == (gtl_info.total_live_bytes - 248));
+
+    //30 nodes for n15's children and one for itself
+    uint64_t expected_final_bytes = 31 * TreeNode30Type.type_size;
+    uint64_t true_final_bytes = gtl_info.total_live_bytes;
+    assert(true_final_bytes == expected_final_bytes);
+
+    garray[1] = nullptr;
+    
+    collect();
+
+    assert(gtl_info.total_live_bytes == 0);
 
     return 0;
 }


### PR DESCRIPTION
- Added some general memstats to help verify accuracy of tests
- All tests now include asserts to verify number of alloc'd bytes matches whats expected
- When an evac page fills, it is inserted onto filled pages list for its GCAllocator 
- Cleaned up bst deletion
- Added check in processDecrements to check that the slot we are exploring isn't a root node. This handles the case where a root node is nested in a larger tree _and_ is still alive, but the larger tree it is apart of dies, preventing our live subtree from being deleted when we walk our large tree's dead root
- Pending decs list is only cleared if it is empty, when running tests with large trees that get deleted it is crucial pending decs list still contains objects that need to be deleted between collection cycles. Without this our pages are full of non reachable allocated objects