### PR TITLE
Stress Tests + BST Fix

### DIFF
--- a/src/runtime/memory/allocator.cpp
+++ b/src/runtime/memory/allocator.cpp
@@ -99,11 +99,11 @@ void GCAllocator::processPage(PageInfo* p) noexcept
     }
     else if(IS_LOW_UTIL(n_util)) {
         GET_BUCKET_INDEX(n_util, NUM_LOW_UTIL_BUCKETS, bucket_index, 0);
-        this->insertPageInBucket(this->low_utilization_buckets, p, n_util, bucket_index);    
+        this->insertPageInBucket(&this->low_utilization_buckets[bucket_index], p, n_util);    
     }
     else if(IS_HIGH_UTIL(n_util)) {
         GET_BUCKET_INDEX(n_util, NUM_HIGH_UTIL_BUCKETS, bucket_index, 1);
-        this->insertPageInBucket(this->high_utilization_buckets, p, n_util, bucket_index);
+        this->insertPageInBucket(&this->high_utilization_buckets[bucket_index], p, n_util);
     }
     //if our page freshly became full we need to gc
     else if(IS_FULL(n_util) && !IS_FULL(old_util)) {
@@ -192,7 +192,13 @@ inline void process(PageInfo* page)
 void traverseBST(PageInfo* node) 
 {
     if (!node) return;
-    process(node);
+
+    PageInfo* current = node;
+    while (current != nullptr) {
+        process(current);
+        current = current->next;
+    }
+    
     traverseBST(node->left);
     traverseBST(node->right); 
 }

--- a/src/runtime/memory/allocator.cpp
+++ b/src/runtime/memory/allocator.cpp
@@ -107,8 +107,15 @@ void GCAllocator::processPage(PageInfo* p) noexcept
     }
     //if our page freshly became full we need to gc
     else if(IS_FULL(n_util) && !IS_FULL(old_util)) {
-        p->next = this->pendinggc_pages;
-        pendinggc_pages = p;
+        //We dont want to collect evac page
+        if(!(p == this->evac_page)) {
+            p->next = this->pendinggc_pages;
+            pendinggc_pages = p;
+        }
+        else {
+            p->next = this->filled_pages;
+            filled_pages = p;
+        }
     }
     //if our page was full before and still full put on filled pages
     else if(IS_FULL(n_util) && IS_FULL(old_util)) {

--- a/src/runtime/memory/allocator.h
+++ b/src/runtime/memory/allocator.h
@@ -284,23 +284,6 @@ private:
         }
     }
 
-    //Actually this bug is fixed now but I am going to leave this big comment
-    //so i can review it thursday morning (i need sleep)
-
-    //
-    //IMPORTANT: Current bug is related to handling pages of same utilization 
-    //in insertion and deletion. Currently there is no proper manner of handing this
-    //which causes tree_shared to fail on larger trees. What appears to be a nice
-    //approach in this context is to just use the next pointer for each page
-    //to create a list if the eq condition holds. 
-    //
-    //ALSO: Make sure to properly use refernces when deleting nodes from the tree.
-    //current deletion logic appears fine in this aspect, but important to keep in mind.
-    //Proper usage of references allow us to get away of not needing to store the previous
-    //node when walking the tree.
-    //
-
-
     void deletePageFromBucket(PageInfo** root_ptr, PageInfo* old_page)
     {
         float old_util = old_page->approx_utilization;

--- a/src/runtime/memory/gc.cpp
+++ b/src/runtime/memory/gc.cpp
@@ -69,29 +69,40 @@ bool pageNeedsMoved(float old_util, float new_util)
         return true;
     }
 
-    const bool was_low = old_util <= 0.60f;
-    const bool now_low = new_util <= 0.60f;
-    
-    if (was_low != now_low) {
+    const bool was_low_util = IS_LOW_UTIL(old_util);
+    const bool now_low_util = IS_LOW_UTIL(new_util);
+    if (was_low_util != now_low_util) {
         return true;
     }
 
-    const bool was_high_util = old_util > 0.90f;
-    const bool now_high_util = new_util > 0.90f;
+    const bool was_high_util = IS_HIGH_UTIL(old_util);
+    const bool now_high_util = IS_HIGH_UTIL(new_util);
     if (was_high_util != now_high_util) {
         return true;
     }
 
-    if (now_low) {
-        int old_bucket, new_bucket = -1;
+    const bool was_full = IS_FULL(old_util);
+    const bool now_full = IS_FULL(new_util);
+    if (was_full != now_full) {
+        return true;
+    }
+
+    if (now_low_util) {
+        int old_bucket = -1; 
+        int new_bucket = -1;
         GET_BUCKET_INDEX(old_util, NUM_LOW_UTIL_BUCKETS, old_bucket, 0);
         GET_BUCKET_INDEX(new_util, NUM_LOW_UTIL_BUCKETS, new_bucket, 0);
         return old_bucket != new_bucket;
-    } else {
-        int old_bucket, new_bucket = -1;
+    } 
+    else if (now_high_util){
+        int old_bucket = -1; 
+        int new_bucket = -1;
         GET_BUCKET_INDEX(old_util, NUM_HIGH_UTIL_BUCKETS, old_bucket, 1);
         GET_BUCKET_INDEX(new_util, NUM_HIGH_UTIL_BUCKETS, new_bucket, 1);
         return old_bucket != new_bucket;
+    }
+    else {
+        return false;
     }
 }
 

--- a/test/multiple_tree_shared.cpp
+++ b/test/multiple_tree_shared.cpp
@@ -1,0 +1,174 @@
+#include "../src/runtime/memory/gc.h"
+#include "../src/runtime/memory/threadinfo.h"
+
+#include <string>
+#include <iostream>
+#include <chrono>
+
+struct TypeInfoBase TreeNode3Type = {
+    .type_id = 1,
+    .type_size = 32,
+    .slot_size = 4,
+    .ptr_mask = "1110",  
+    .typekey = "TreeNode3Type"
+};
+
+struct TypeInfoBase TreeNode1Type = {
+    .type_id = 2,
+    .type_size = 16,
+    .slot_size = 2,
+    .ptr_mask = "10",  
+    .typekey = "TreeNode1Type"
+};
+
+struct TreeNode3Value {
+    TreeNode3Value* n1;
+    TreeNode3Value* n2;
+    TreeNode3Value* n3;
+    int64_t val;
+};
+
+struct TreeNode1Value {
+    TreeNode3Value* n1;
+    int64_t val;
+};
+
+GCAllocator alloc4(32, REAL_ENTRY_SIZE(32), collect);
+GCAllocator alloc2(16, REAL_ENTRY_SIZE(16), collect);
+
+//
+//Make tree recursively (for now)
+//
+TreeNode3Value* makeSharedTree(int64_t depth, int64_t val) {
+    if (depth < 0) {
+        return nullptr; 
+    }
+
+    TreeNode3Value* n = AllocType(TreeNode3Value, alloc4, &TreeNode3Type);
+    n->val = val;
+
+    n->n1 = makeSharedTree(depth - 1, val + 1);
+    n->n2 = makeSharedTree(depth - 1, val + 1);
+    n->n3 = makeSharedTree(depth - 1, val + 1);
+
+    return n;
+}
+
+std::string printtree(void* node) {
+    if (node == nullptr) {
+        return "null"; 
+    }
+
+    std::string addr = "xx"; 
+    std::string nodeStr;
+
+    std::string childStrs;
+    TypeInfoBase* type = GC_TYPE(node);
+    if(type == &TreeNode1Type) {
+        TreeNode1Value* n = static_cast<TreeNode1Value*>(node);
+        nodeStr = "[" + addr + ", " + std::to_string(n->val) + "]";
+        childStrs += printtree(n->n1);
+    }
+    else if(type == &TreeNode3Type) {
+        TreeNode3Value* n = static_cast<TreeNode3Value*>(node);
+        nodeStr = "[" + addr + ", " + std::to_string(n->val) + "]";
+        childStrs += printtree(n->n1) + ", ";
+        childStrs += printtree(n->n2) + ", ";
+        childStrs += printtree(n->n3);
+    }
+
+    return nodeStr + ", " + childStrs;
+}
+
+uint64_t find_size_bytes(TreeNode3Value* n) 
+{
+    if(n == nullptr) {
+        return 0;
+    }
+
+    return TreeNode3Type.type_size + 
+           find_size_bytes(n->n1) + 
+           find_size_bytes(n->n2) + 
+           find_size_bytes(n->n3);
+}
+
+void* garray[3] = {nullptr, nullptr, nullptr};
+
+//
+//This test creates similar shared tree as in tree_shared
+//but we create multiple as a sort of stress test
+//for the collector
+//
+int main(int argc, char **argv)
+{
+    INIT_LOCKS();
+    GlobalDataStorage::g_global_data.initialize(sizeof(garray), garray);
+
+    InitBSQMemoryTheadLocalInfo();
+    gtl_info.disable_automatic_collections = true;
+    gtl_info.disable_stack_refs_for_tests = true;
+
+    GCAllocator* allocs[2] = { &alloc2, &alloc4 };
+    gtl_info.initializeGC<2>(allocs);
+
+    const int depth = 11;
+    const int iterations = 1000;
+    int failed_iterations = 0;
+
+    std::cout << "Starting " << iterations << " iterations of GC stress testing...\n";
+    auto test_start = std::chrono::high_resolution_clock::now();
+
+    for (int i = 0; i < iterations; i++) {
+        auto iter_start = std::chrono::high_resolution_clock::now();
+
+        // Create big tree and keep a subtree alive
+        TreeNode3Value* root1 = makeSharedTree(depth, 2);
+        garray[0] = root1;
+        TreeNode1Value* root2 = AllocType(TreeNode1Value, alloc2, &TreeNode1Type);
+        root2->val = 2;
+        garray[1] = root2;
+        root2->n1 = root1->n1->n1;
+
+        // Drop root1 and collect
+        garray[0] = nullptr;
+        for (int j = 0; j < 6; j++) {
+            collect();
+        }
+
+        // Verify kept subtree is intact
+        uint64_t subtree_size = find_size_bytes(root2->n1);
+        uint64_t expected_size = subtree_size + TreeNode1Type.type_size;
+        if (gtl_info.total_live_bytes != expected_size) {
+            std::cerr << "Iteration " << i << " failed: incorrect live bytes\n";
+            failed_iterations++;
+            continue;
+        }
+
+        // Drop everything and collect
+        garray[1] = nullptr;
+        for (int j = 0; j < 6; j++) {
+            collect();
+        }
+
+        if (gtl_info.total_live_bytes != 0) {
+            std::cerr << "Iteration " << i << " failed: memory not fully collected\n";
+            failed_iterations++;
+        }
+
+        auto iter_end = std::chrono::high_resolution_clock::now();
+        auto iter_time = std::chrono::duration_cast<std::chrono::milliseconds>(iter_end - iter_start).count();
+        if (iter_time > 100) {
+            std::cout << "Iteration " << i << " took " << iter_time << "ms\n";
+        }
+    }
+
+    //Didn't do these calculations in other tests but fun to see
+    auto test_end = std::chrono::high_resolution_clock::now();
+    auto total_time_ms = std::chrono::duration_cast<std::chrono::milliseconds>(test_end - test_start).count();
+    double total_time_seconds = total_time_ms / 1000.0;
+
+    std::cout << "\nTest completed in " << std::fixed << std::setprecision(3) << total_time_seconds << " seconds\n";
+
+    std::cout << "Failed iterations: " << failed_iterations << "/" << iterations << "\n";
+    return failed_iterations > 0 ? 1 : 0;
+}

--- a/test/multiple_tree_wide_drop_child.cpp
+++ b/test/multiple_tree_wide_drop_child.cpp
@@ -1,0 +1,226 @@
+#include "../src/runtime/memory/gc.h"
+#include "../src/runtime/memory/threadinfo.h"
+
+#include <string>
+#include <chrono>
+#include <iostream>
+
+struct TypeInfoBase TreeNode30Type = {
+    .type_id = 1,
+    .type_size = 248,
+    .slot_size = 31,
+    .ptr_mask = "1111111111111111111111111111110",  
+    .typekey = "TreeNode30Type"
+};
+
+struct TreeNodeValue {
+    TreeNodeValue* n1;
+    TreeNodeValue* n2;
+    TreeNodeValue* n3;
+    TreeNodeValue* n4;
+    TreeNodeValue* n5;
+    TreeNodeValue* n6;
+    TreeNodeValue* n7;
+    TreeNodeValue* n8;
+    TreeNodeValue* n9;
+    TreeNodeValue* n10;
+    TreeNodeValue* n11;
+    TreeNodeValue* n12;
+    TreeNodeValue* n13;
+    TreeNodeValue* n14;
+    TreeNodeValue* n15;
+    TreeNodeValue* n16;
+    TreeNodeValue* n17;
+    TreeNodeValue* n18;
+    TreeNodeValue* n19;
+    TreeNodeValue* n20;
+    TreeNodeValue* n21;
+    TreeNodeValue* n22;
+    TreeNodeValue* n23;
+    TreeNodeValue* n24;
+    TreeNodeValue* n25;
+    TreeNodeValue* n26;
+    TreeNodeValue* n27;
+    TreeNodeValue* n28;
+    TreeNodeValue* n29;
+    TreeNodeValue* n30;
+
+    int64_t val;
+};
+
+GCAllocator alloc248(248, REAL_ENTRY_SIZE(248), collect);
+
+//
+//Make tree recursively (for now)
+//
+TreeNodeValue* makeTree(int64_t depth, int64_t val) {
+    if (depth < 0) {
+        return nullptr; 
+    }
+
+    TreeNodeValue* n = AllocType(TreeNodeValue, alloc248, &TreeNode30Type);
+    n->val = val;
+
+    n->n1 = makeTree(depth - 1, val + 1);
+    n->n2 = makeTree(depth - 1, val + 1);
+    n->n3 = makeTree(depth - 1, val + 1);
+    n->n4 = makeTree(depth - 1, val + 1);
+    n->n5 = makeTree(depth - 1, val + 1);
+    n->n6 = makeTree(depth - 1, val + 1);
+    n->n7 = makeTree(depth - 1, val + 1);
+    n->n8 = makeTree(depth - 1, val + 1);
+    n->n9 = makeTree(depth - 1, val + 1);
+    n->n10 = makeTree(depth - 1, val + 1);
+    n->n11 = makeTree(depth - 1, val + 1);
+    n->n12 = makeTree(depth - 1, val + 1);
+    n->n13 = makeTree(depth - 1, val + 1);
+    n->n14 = makeTree(depth - 1, val + 1);
+    n->n15 = makeTree(depth - 1, val + 1);
+    n->n16 = makeTree(depth - 1, val + 1);
+    n->n17 = makeTree(depth - 1, val + 1);
+    n->n18 = makeTree(depth - 1, val + 1);
+    n->n19 = makeTree(depth - 1, val + 1);
+    n->n20 = makeTree(depth - 1, val + 1);
+    n->n21 = makeTree(depth - 1, val + 1);
+    n->n22 = makeTree(depth - 1, val + 1);
+    n->n23 = makeTree(depth - 1, val + 1);
+    n->n24 = makeTree(depth - 1, val + 1);
+    n->n25 = makeTree(depth - 1, val + 1);
+    n->n26 = makeTree(depth - 1, val + 1);
+    n->n27 = makeTree(depth - 1, val + 1);
+    n->n28 = makeTree(depth - 1, val + 1);
+    n->n29 = makeTree(depth - 1, val + 1);
+    n->n30 = makeTree(depth - 1, val + 1);
+
+    return n;
+}
+
+std::string printtree(TreeNodeValue* node) {
+    if (node == nullptr) {
+        return "null"; 
+    }
+
+    std::string addr = "xx"; 
+    std::string nodeStr = "[" + addr + ", " + std::to_string(node->val) + "]";
+
+    std::string childStrs;
+    childStrs += printtree(node->n1) + ", ";
+    childStrs += printtree(node->n2) + ", ";
+    childStrs += printtree(node->n3) + ", ";
+    childStrs += printtree(node->n4) + ", ";
+    childStrs += printtree(node->n5) + ", ";
+    childStrs += printtree(node->n6) + ", ";
+    childStrs += printtree(node->n7) + ", ";
+    childStrs += printtree(node->n8) + ", ";
+    childStrs += printtree(node->n9) + ", ";
+    childStrs += printtree(node->n10) + ", ";
+    childStrs += printtree(node->n11) + ", ";
+    childStrs += printtree(node->n12) + ", ";
+    childStrs += printtree(node->n13) + ", ";
+    childStrs += printtree(node->n14) + ", ";
+    childStrs += printtree(node->n15) + ", ";
+    childStrs += printtree(node->n16) + ", ";
+    childStrs += printtree(node->n17) + ", ";
+    childStrs += printtree(node->n18) + ", ";
+    childStrs += printtree(node->n19) + ", ";
+    childStrs += printtree(node->n20) + ", ";
+    childStrs += printtree(node->n21) + ", ";
+    childStrs += printtree(node->n22) + ", ";
+    childStrs += printtree(node->n23) + ", ";
+    childStrs += printtree(node->n24) + ", ";
+    childStrs += printtree(node->n25) + ", ";
+    childStrs += printtree(node->n26) + ", ";
+    childStrs += printtree(node->n27) + ", ";
+    childStrs += printtree(node->n28) + ", ";
+    childStrs += printtree(node->n29) + ", ";
+    childStrs += printtree(node->n30);
+
+    return nodeStr + ", " + childStrs;
+}
+
+TreeNodeValue* garray[3] = {nullptr, nullptr, nullptr};
+
+//
+//Purpose of this test is to create a very wide tree
+//then drop some subtrees
+//
+int main(int argc, char **argv)
+{
+    INIT_LOCKS();
+    GlobalDataStorage::g_global_data.initialize(sizeof(garray), (void**)garray);
+
+    InitBSQMemoryTheadLocalInfo();
+    gtl_info.disable_automatic_collections = true;
+    gtl_info.disable_stack_refs_for_tests = true;
+
+    GCAllocator* allocs[1] = { &alloc248 };
+    gtl_info.initializeGC<1>(allocs);
+
+    const int depth = 2;
+    const int iterations = 1000;
+    int failed_iterations = 0;
+
+    std::cout << "Starting " << iterations << " iterations of GC stress testing for multiple_tree_wide_drop_child...\n";
+    auto test_start = std::chrono::high_resolution_clock::now();
+
+    for (int i = 0; i < iterations; i++) {        
+        TreeNodeValue* root = makeTree(depth, 2);
+        garray[0] = root;
+
+        root->n1 = nullptr;
+        root->n3 = nullptr;
+        root->n5 = nullptr;
+        root->n7 = nullptr;
+        root->n9 = nullptr;
+        root->n11 = nullptr;
+        root->n13 = nullptr;
+        root->n15 = nullptr;
+        root->n17 = nullptr;
+        root->n19 = nullptr;
+        root->n21 = nullptr;
+        root->n23 = nullptr;
+        root->n25 = nullptr;
+        root->n27 = nullptr;
+        root->n29 = nullptr;
+
+        uint64_t init_total_bytes = ((1 + 15 + 15*30) * TreeNode30Type.type_size);
+
+        auto root_init = printtree(garray[0]);
+        auto root0_init = printtree(garray[1]);
+
+        collect();
+
+        auto root_final = printtree(garray[0]);
+        auto root0_final = printtree(garray[1]);
+
+        if(!((root_init == root_final) == (root0_init == root0_final))) {
+            std::cerr << "Iteration " << i << " failed: subtree not intact after collection\n";
+            failed_iterations++;
+            continue;
+        }
+
+        if(init_total_bytes != gtl_info.total_live_bytes) {
+            std::cerr << "Iteration " << i << " failed: incorrect live bytes\n";
+            failed_iterations++;
+            continue;
+        }
+
+        garray[0] = nullptr;
+        collect();
+        
+        if (gtl_info.total_live_bytes != 0) {
+            std::cerr << "Iteration " << i << " failed: memory not fully collected\n";
+            failed_iterations++;
+        }
+    }
+
+    //I may be having too much fun with these statistics
+    auto test_end = std::chrono::high_resolution_clock::now();
+    auto total_time_ms = std::chrono::duration_cast<std::chrono::milliseconds>(test_end - test_start).count();
+    double total_time_seconds = total_time_ms / 1000.0;
+
+    std::cout << "\nTest completed in " << std::fixed << std::setprecision(3) << total_time_seconds << " seconds\n";
+
+    std::cout << "Failed iterations: " << failed_iterations << "/" << iterations << "\n";
+    return failed_iterations > 0 ? 1 : 0;
+}

--- a/test/nbody.cpp
+++ b/test/nbody.cpp
@@ -309,7 +309,7 @@ int main(int argc, char** argv)
     Body** sys = createNBodySystem();
     double step = 0.01;
     
-    printf("energy: %g\n", energy(sys));
+    printf("energy: %.9g\n", energy(sys));
 
     //Lets collect every 10000 systems
     for(int i = 0; i < n; i++) {
@@ -319,7 +319,7 @@ int main(int argc, char** argv)
         }
     }
 
-    printf("energy: %g\n", energy(sys));
+    printf("energy: %.9g\n", energy(sys));
 
     return 0;
 }

--- a/test/tree_deep.cpp
+++ b/test/tree_deep.cpp
@@ -96,7 +96,7 @@ int main(int argc, char** argv) {
     GCAllocator* allocs[1] = { &alloc3 };
     gtl_info.initializeGC<1>(allocs);
 
-    int depth = 13;
+    int depth = 15;
     TreeNodeValue* tree_root = makeTree(depth, 4);
     garray[0] = tree_root;
 
@@ -114,6 +114,13 @@ int main(int argc, char** argv) {
 
     gtl_info.disable_stack_refs_for_tests = true;
     garray[0] = nullptr;
+
+    //big tree, so collect a few times to clear up pending decs
+    collect();
+    collect();
+    collect();
+    collect();
+    collect();
     collect();
 
     assert(gtl_info.total_live_bytes == 0);

--- a/test/tree_deep.cpp
+++ b/test/tree_deep.cpp
@@ -84,8 +84,6 @@ TreeNodeValue* garray[3] = {nullptr, nullptr, nullptr};
 //Full tree of varrying depths
 //A possible improvement could be making tree for each depth up to a certain threshold (say n=14)
 //
-
-//TODO: figure out why we are off by exactly one treenode type size in our final calculation
 int main(int argc, char** argv) {
     INIT_LOCKS();
     GlobalDataStorage::g_global_data.initialize(sizeof(garray), (void**)garray);

--- a/test/tree_diamond.cpp
+++ b/test/tree_diamond.cpp
@@ -1,0 +1,120 @@
+#include "../src/runtime/memory/gc.h"
+#include "../src/runtime/memory/threadinfo.h"
+
+#include <string>
+#include <format>
+
+struct TypeInfoBase TreeNode2Type = {
+    .type_id = 1,
+    .type_size = 24,
+    .slot_size = 3,
+    .ptr_mask = "110",  
+    .typekey = "TreeNode2Type"
+};
+
+struct TypeInfoBase TreeNode1Type = {
+    .type_id = 2,
+    .type_size = 16,
+    .slot_size = 2,
+    .ptr_mask = "10",  
+    .typekey = "TreeNode1Type"
+};
+
+struct TreeNode2Value {
+    void* left;
+    void* right;
+    int64_t val;
+};
+
+struct TreeNode1Value {
+    void* next;
+    int64_t val;
+};
+
+GCAllocator alloc2(16, REAL_ENTRY_SIZE(16), collect);
+GCAllocator alloc3(24, REAL_ENTRY_SIZE(24), collect);
+
+std::string printtree(void* node) 
+{
+    if (node == nullptr) {
+        return "null";
+    }
+
+    std::string addr = "xx"; 
+    std::string nodeStr;
+
+    std::string childStrs;
+    TypeInfoBase* type = GC_TYPE(node);
+
+    if (type == &TreeNode1Type) {
+        TreeNode1Value* n1 = static_cast<TreeNode1Value*>(node);
+        nodeStr = "[" + addr + ", " + std::to_string(n1->val) + "]";
+        childStrs += printtree(n1->next);
+    }
+    else if (type == &TreeNode2Type) {
+        TreeNode2Value* n2 = static_cast<TreeNode2Value*>(node);
+        nodeStr = "[" + addr + ", " + std::to_string(n2->val) + "]";
+        childStrs += printtree(n2->left) + ", " + printtree(n2->right);
+    }
+    else {
+        return "null";
+    }
+
+    return nodeStr + ", " + childStrs;
+}
+
+void* garray[3] = {nullptr, nullptr, nullptr};
+
+//
+//Simple diamond structure tree
+//
+int main(int argc, char** argv) {
+    INIT_LOCKS();
+    GlobalDataStorage::g_global_data.initialize(sizeof(garray), garray);
+
+    InitBSQMemoryTheadLocalInfo();
+    gtl_info.disable_automatic_collections = true;
+    gtl_info.disable_stack_refs_for_tests= true;
+
+    GCAllocator* allocs[2] = { &alloc2, &alloc3 };
+    gtl_info.initializeGC<2>(allocs);
+
+    TreeNode2Value* root = AllocType(TreeNode2Value, alloc3, &TreeNode2Type);
+    root->val = 1;
+    garray[0] = root;
+
+    TreeNode1Value* l = AllocType(TreeNode1Value, alloc2, &TreeNode1Type);
+    l->val = 2;
+    root->left = l;
+
+    TreeNode1Value* r = AllocType(TreeNode1Value, alloc2, &TreeNode1Type);
+    r->val = 2;
+    root->right = r;
+
+    TreeNode1Value* end = AllocType(TreeNode1Value, alloc2, &TreeNode1Type);
+    end->val = 3;
+    end->next = nullptr;
+
+    l->next = end;
+    r->next = end;
+
+    //root node has two pointers, rest have one
+    uint64_t init_total_bytes = 24 + 16 + 16 + 16;
+
+    auto t1_start = printtree(root);
+    
+    collect();
+
+    auto t1_end = printtree(root);
+    assert(t1_start == t1_end);
+
+    assert(init_total_bytes == gtl_info.total_live_bytes);
+
+    garray[0] = nullptr;
+
+    collect();
+
+    assert(gtl_info.total_live_bytes == 0);
+
+    return 0;
+}

--- a/test/tree_shared.cpp
+++ b/test/tree_shared.cpp
@@ -111,7 +111,7 @@ int main(int argc, char **argv)
     GCAllocator* allocs[2] = { &alloc2, &alloc4 };
     gtl_info.initializeGC<2>(allocs);
 
-    int depth = 10;
+    int depth = 4;
     TreeNode3Value* root1 = makeSharedTree(depth, 2);
     garray[0] = root1;
     TreeNode1Value* root2 = AllocType(TreeNode1Value, alloc2, &TreeNode1Type);
@@ -151,6 +151,7 @@ int main(int argc, char **argv)
     collect();
     collect();
     collect();
+
 
     assert(gtl_info.total_live_bytes == 0);
 

--- a/test/tree_shared.cpp
+++ b/test/tree_shared.cpp
@@ -158,7 +158,6 @@ int main(int argc, char **argv)
     collect();
     collect();
 
-
     assert(gtl_info.total_live_bytes == 0);
 
     return 0;

--- a/test/tree_shared.cpp
+++ b/test/tree_shared.cpp
@@ -1,0 +1,158 @@
+#include "../src/runtime/memory/gc.h"
+#include "../src/runtime/memory/threadinfo.h"
+
+#include <string>
+#include <format>
+#include <iostream>
+
+struct TypeInfoBase TreeNode3Type = {
+    .type_id = 1,
+    .type_size = 32,
+    .slot_size = 4,
+    .ptr_mask = "1110",  
+    .typekey = "TreeNode3Type"
+};
+
+struct TypeInfoBase TreeNode1Type = {
+    .type_id = 2,
+    .type_size = 16,
+    .slot_size = 2,
+    .ptr_mask = "10",  
+    .typekey = "TreeNode1Type"
+};
+
+struct TreeNode3Value {
+    TreeNode3Value* n1;
+    TreeNode3Value* n2;
+    TreeNode3Value* n3;
+    int64_t val;
+};
+
+struct TreeNode1Value {
+    TreeNode3Value* n1;
+    int64_t val;
+};
+
+GCAllocator alloc4(32, REAL_ENTRY_SIZE(32), collect);
+GCAllocator alloc2(16, REAL_ENTRY_SIZE(16), collect);
+
+//
+//Make tree recursively (for now)
+//
+TreeNode3Value* makeSharedTree(int64_t depth, int64_t val) {
+    if (depth < 0) {
+        return nullptr; 
+    }
+
+    TreeNode3Value* n = AllocType(TreeNode3Value, alloc4, &TreeNode3Type);
+    n->val = val;
+
+    n->n1 = makeSharedTree(depth - 1, val + 1);
+    n->n2 = makeSharedTree(depth - 1, val + 1);
+    n->n3 = makeSharedTree(depth - 1, val + 1);
+
+    return n;
+}
+
+std::string printtree(void* node) {
+    if (node == nullptr) {
+        return "null"; 
+    }
+
+    std::string addr = "xx"; 
+    std::string nodeStr;
+
+    std::string childStrs;
+    TypeInfoBase* type = GC_TYPE(node);
+    if(type == &TreeNode1Type) {
+        TreeNode1Value* n = static_cast<TreeNode1Value*>(node);
+        nodeStr = "[" + addr + ", " + std::to_string(n->val) + "]";
+        childStrs += printtree(n->n1);
+    }
+    else if(type == &TreeNode3Type) {
+        TreeNode3Value* n = static_cast<TreeNode3Value*>(node);
+        nodeStr = "[" + addr + ", " + std::to_string(n->val) + "]";
+        childStrs += printtree(n->n1) + ", ";
+        childStrs += printtree(n->n2) + ", ";
+        childStrs += printtree(n->n3);
+    }
+
+    return nodeStr + ", " + childStrs;
+}
+
+uint64_t find_size_bytes(TreeNode3Value* n) 
+{
+    if(n == nullptr) {
+        return 0;
+    }
+
+    return TreeNode3Type.type_size + 
+           find_size_bytes(n->n1) + 
+           find_size_bytes(n->n2) + 
+           find_size_bytes(n->n3);
+}
+
+void* garray[3] = {nullptr, nullptr, nullptr};
+
+//
+//Create one tree, then have one of its sub trees
+//be pointed to my a root object, keeping it alive
+//after bigger trees root is dropped
+//
+int main(int argc, char **argv)
+{
+    INIT_LOCKS();
+    GlobalDataStorage::g_global_data.initialize(sizeof(garray), garray);
+
+    InitBSQMemoryTheadLocalInfo();
+    gtl_info.disable_automatic_collections = true;
+    gtl_info.disable_stack_refs_for_tests = true;
+
+    GCAllocator* allocs[2] = { &alloc2, &alloc4 };
+    gtl_info.initializeGC<2>(allocs);
+
+    int depth = 10;
+    TreeNode3Value* root1 = makeSharedTree(depth, 2);
+    garray[0] = root1;
+    TreeNode1Value* root2 = AllocType(TreeNode1Value, alloc2, &TreeNode1Type);
+    root2->val = 2; //we started with 2 as value for root1
+    garray[1] = root2;
+
+    //keep this subtree alive
+    root2->n1 = root1->n1->n1;
+
+    auto root1_init = printtree(root1);
+    auto root2_init = printtree(root2);
+
+    collect();
+
+    //drop root1
+    garray[0] = nullptr;
+    
+    collect();
+
+    auto root2_final = printtree(root2);
+    assert(root2_init == root2_final);
+
+    uint64_t subtree_size_bytes = find_size_bytes(root2->n1);
+
+    //We should not lose root2's tree
+    uint64_t expected_root2_final_bytes = subtree_size_bytes + TreeNode1Type.type_size;
+    uint64_t final = gtl_info.total_live_bytes;
+    assert(final == expected_root2_final_bytes);
+
+    garray[1] = nullptr;
+
+    //We have a pretty big tree here, so we need lots of collections to clear out pending decs
+    collect();
+    collect();
+    collect();
+    collect();
+    collect();
+    collect();
+    collect();
+
+    assert(gtl_info.total_live_bytes == 0);
+
+    return 0;
+}

--- a/test/tree_shared.cpp
+++ b/test/tree_shared.cpp
@@ -111,7 +111,7 @@ int main(int argc, char **argv)
     GCAllocator* allocs[2] = { &alloc2, &alloc4 };
     gtl_info.initializeGC<2>(allocs);
 
-    int depth = 4;
+    int depth = 10;
     TreeNode3Value* root1 = makeSharedTree(depth, 2);
     garray[0] = root1;
     TreeNode1Value* root2 = AllocType(TreeNode1Value, alloc2, &TreeNode1Type);
@@ -129,6 +129,12 @@ int main(int argc, char **argv)
     //drop root1
     garray[0] = nullptr;
     
+    //We have a pretty big tree here, so we need lots of collections to clear out pending decs
+    collect();
+    collect();
+    collect();
+    collect();
+    collect();
     collect();
 
     auto root2_final = printtree(root2);

--- a/test/tree_wide_drop_child.cpp
+++ b/test/tree_wide_drop_child.cpp
@@ -1,0 +1,199 @@
+#include "../src/runtime/memory/gc.h"
+#include "../src/runtime/memory/threadinfo.h"
+
+#include <string>
+#include <format>
+#include <iostream>
+
+struct TypeInfoBase TreeNode30Type = {
+    .type_id = 1,
+    .type_size = 248,
+    .slot_size = 31,
+    .ptr_mask = "1111111111111111111111111111110",  
+    .typekey = "TreeNode30Type"
+};
+
+struct TreeNodeValue {
+    TreeNodeValue* n1;
+    TreeNodeValue* n2;
+    TreeNodeValue* n3;
+    TreeNodeValue* n4;
+    TreeNodeValue* n5;
+    TreeNodeValue* n6;
+    TreeNodeValue* n7;
+    TreeNodeValue* n8;
+    TreeNodeValue* n9;
+    TreeNodeValue* n10;
+    TreeNodeValue* n11;
+    TreeNodeValue* n12;
+    TreeNodeValue* n13;
+    TreeNodeValue* n14;
+    TreeNodeValue* n15;
+    TreeNodeValue* n16;
+    TreeNodeValue* n17;
+    TreeNodeValue* n18;
+    TreeNodeValue* n19;
+    TreeNodeValue* n20;
+    TreeNodeValue* n21;
+    TreeNodeValue* n22;
+    TreeNodeValue* n23;
+    TreeNodeValue* n24;
+    TreeNodeValue* n25;
+    TreeNodeValue* n26;
+    TreeNodeValue* n27;
+    TreeNodeValue* n28;
+    TreeNodeValue* n29;
+    TreeNodeValue* n30;
+
+    int64_t val;
+};
+
+GCAllocator alloc248(248, REAL_ENTRY_SIZE(248), collect);
+
+//
+//Make tree recursively (for now)
+//
+TreeNodeValue* makeTree(int64_t depth, int64_t val) {
+    if (depth < 0) {
+        return nullptr; 
+    }
+
+    TreeNodeValue* n = AllocType(TreeNodeValue, alloc248, &TreeNode30Type);
+    n->val = val;
+
+    n->n1 = makeTree(depth - 1, val + 1);
+    n->n2 = makeTree(depth - 1, val + 1);
+    n->n3 = makeTree(depth - 1, val + 1);
+    n->n4 = makeTree(depth - 1, val + 1);
+    n->n5 = makeTree(depth - 1, val + 1);
+    n->n6 = makeTree(depth - 1, val + 1);
+    n->n7 = makeTree(depth - 1, val + 1);
+    n->n8 = makeTree(depth - 1, val + 1);
+    n->n9 = makeTree(depth - 1, val + 1);
+    n->n10 = makeTree(depth - 1, val + 1);
+    n->n11 = makeTree(depth - 1, val + 1);
+    n->n12 = makeTree(depth - 1, val + 1);
+    n->n13 = makeTree(depth - 1, val + 1);
+    n->n14 = makeTree(depth - 1, val + 1);
+    n->n15 = makeTree(depth - 1, val + 1);
+    n->n16 = makeTree(depth - 1, val + 1);
+    n->n17 = makeTree(depth - 1, val + 1);
+    n->n18 = makeTree(depth - 1, val + 1);
+    n->n19 = makeTree(depth - 1, val + 1);
+    n->n20 = makeTree(depth - 1, val + 1);
+    n->n21 = makeTree(depth - 1, val + 1);
+    n->n22 = makeTree(depth - 1, val + 1);
+    n->n23 = makeTree(depth - 1, val + 1);
+    n->n24 = makeTree(depth - 1, val + 1);
+    n->n25 = makeTree(depth - 1, val + 1);
+    n->n26 = makeTree(depth - 1, val + 1);
+    n->n27 = makeTree(depth - 1, val + 1);
+    n->n28 = makeTree(depth - 1, val + 1);
+    n->n29 = makeTree(depth - 1, val + 1);
+    n->n30 = makeTree(depth - 1, val + 1);
+
+    return n;
+}
+
+std::string printtree(TreeNodeValue* node) {
+    if (node == nullptr) {
+        return "null"; 
+    }
+
+    std::string addr = "xx"; 
+    std::string nodeStr = "[" + addr + ", " + std::to_string(node->val) + "]";
+
+    std::string childStrs;
+    childStrs += printtree(node->n1) + ", ";
+    childStrs += printtree(node->n2) + ", ";
+    childStrs += printtree(node->n3) + ", ";
+    childStrs += printtree(node->n4) + ", ";
+    childStrs += printtree(node->n5) + ", ";
+    childStrs += printtree(node->n6) + ", ";
+    childStrs += printtree(node->n7) + ", ";
+    childStrs += printtree(node->n8) + ", ";
+    childStrs += printtree(node->n9) + ", ";
+    childStrs += printtree(node->n10) + ", ";
+    childStrs += printtree(node->n11) + ", ";
+    childStrs += printtree(node->n12) + ", ";
+    childStrs += printtree(node->n13) + ", ";
+    childStrs += printtree(node->n14) + ", ";
+    childStrs += printtree(node->n15) + ", ";
+    childStrs += printtree(node->n16) + ", ";
+    childStrs += printtree(node->n17) + ", ";
+    childStrs += printtree(node->n18) + ", ";
+    childStrs += printtree(node->n19) + ", ";
+    childStrs += printtree(node->n20) + ", ";
+    childStrs += printtree(node->n21) + ", ";
+    childStrs += printtree(node->n22) + ", ";
+    childStrs += printtree(node->n23) + ", ";
+    childStrs += printtree(node->n24) + ", ";
+    childStrs += printtree(node->n25) + ", ";
+    childStrs += printtree(node->n26) + ", ";
+    childStrs += printtree(node->n27) + ", ";
+    childStrs += printtree(node->n28) + ", ";
+    childStrs += printtree(node->n29) + ", ";
+    childStrs += printtree(node->n30);
+
+    return nodeStr + ", " + childStrs;
+}
+
+TreeNodeValue* garray[3] = {nullptr, nullptr, nullptr};
+
+//
+//Purpose of this test is to create a very wide tree
+//then drop some subtrees
+//
+int main(int argc, char **argv)
+{
+    INIT_LOCKS();
+    GlobalDataStorage::g_global_data.initialize(sizeof(garray), (void**)garray);
+
+    InitBSQMemoryTheadLocalInfo();
+    gtl_info.disable_automatic_collections = true;
+    gtl_info.disable_stack_refs_for_tests = true;
+
+    GCAllocator* allocs[1] = { &alloc248 };
+    gtl_info.initializeGC<1>(allocs);
+
+    //These two trees should print the same output
+    int depth = 2;
+    TreeNodeValue* root = makeTree(depth, 2);
+    garray[0] = root;
+
+    root->n1 = nullptr;
+    root->n3 = nullptr;
+    root->n5 = nullptr;
+    root->n7 = nullptr;
+    root->n9 = nullptr;
+    root->n11 = nullptr;
+    root->n13 = nullptr;
+    root->n15 = nullptr;
+    root->n17 = nullptr;
+    root->n19 = nullptr;
+    root->n21 = nullptr;
+    root->n23 = nullptr;
+    root->n25 = nullptr;
+    root->n27 = nullptr;
+    root->n29 = nullptr;
+
+    uint64_t init_total_bytes = ((1 + 15 + 15*30) * TreeNode30Type.type_size);
+
+    auto root_init = printtree(garray[0]);
+    auto root0_init = printtree(garray[1]);
+
+    collect();
+
+    auto root_final = printtree(garray[0]);
+    auto root0_final = printtree(garray[1]);
+
+    assert((root_init == root_final) == (root0_init == root0_final));
+    assert(init_total_bytes == gtl_info.total_live_bytes);
+
+    garray[0] = nullptr;
+    collect();
+    
+    assert(gtl_info.total_live_bytes == 0);
+    
+    return 0;
+}


### PR DESCRIPTION
- wrote 5 more tests, tree_wide_drop_child, multiple_tree_wide_drop_child, tree_shared, multiple_tree_shared, and tree_diamond. The tests with "multiple" prefix are more so stress tests with same format as their corresponding singular tree test but run something like 100 times to make sure our collector can handle lots of large trees being allocated and deleted (and more interesting cases where we need to not delete subtrees)
- our bst's now store elements with the same utilization in a list (using their next pointer) rather than just naively placing them in their tree. This fixes bugs in relation to pages seemingly being lost because they were stuck in their tree and never found when calculating memstats and in next collection cycle

All of our tests currently pass given checks for correct amount of alloc'd bytes present and check that their structures are preserved properly. There is still lots of room for optimizations, but our collector _appears_ to be in decent shape!