### PR TITLE
performace metrics code

### DIFF
--- a/src/runtime/common.cpp
+++ b/src/runtime/common.cpp
@@ -6,4 +6,3 @@ mtx_t g_gcrefctlock;
 
 size_t GlobalThreadAllocInfo::s_thread_counter = 0;
 void* GlobalThreadAllocInfo::s_current_page_address = ALLOC_BASE_ADDRESS;
-uint32_t GlobalThreadAllocInfo::newly_filled_pages_count = 0;

--- a/src/runtime/memory/gc.cpp
+++ b/src/runtime/memory/gc.cpp
@@ -359,7 +359,6 @@ void collect() noexcept
     xmem_zerofill(gtl_info.forward_table, gtl_info.forward_table_index);
     gtl_info.forward_table_index = 0;
 
-
     if(should_reset_pending_decs) {
         gtl_info.pending_decs.initialize();
         should_reset_pending_decs = false;
@@ -392,13 +391,16 @@ void collect() noexcept
 
     xmem_zerofill(gtl_info.roots, gtl_info.roots_count);
     gtl_info.roots_count = 0;
-    GlobalThreadAllocInfo::newly_filled_pages_count = 0;
+    gtl_info.newly_filled_pages_count = 0;
 
 #ifdef MEM_STATS
     auto end = std::chrono::high_resolution_clock::now();
-    std::chrono::duration<double, std::milli> elapsed = end - start;
 
-    gtl_info.collection_times[gtl_info.collection_times_index] = elapsed.count();
-    gtl_info.collection_times_index = (gtl_info.collection_times_index + 1) % MAX_COLLECTION_TIMES_INDEX;
+    double duration_ms = std::chrono::duration_cast<std::chrono::duration<double, std::milli>>(end - start).count();
+    
+    gtl_info.collection_times[gtl_info.collection_times_index++] = duration_ms;
+    if(gtl_info.collection_times_index == 512) {
+        gtl_info.collection_times_index = 0;
+    }
 #endif
 }

--- a/src/runtime/memory/threadinfo.h
+++ b/src/runtime/memory/threadinfo.h
@@ -2,6 +2,12 @@
 
 #include "allocator.h"
 
+//Seems that chrono is pretty fast and shouldn't mess with our metrics too much here
+#ifdef MEM_STATS
+#include <chrono>
+#define MAX_COLLECTION_TIMES_INDEX 512
+#endif
+
 #define InitBSQMemoryTheadLocalInfo() { ALLOC_LOCK_ACQUIRE(); register void** rbp asm("rbp"); gtl_info.initialize(GlobalThreadAllocInfo::s_thread_counter++, rbp); ALLOC_LOCK_RELEASE(); }
 
 #define MARK_STACK_NODE_COLOR_GREY 0
@@ -78,6 +84,9 @@ struct BSQMemoryTheadLocalInfo
     uint64_t total_gc_pages = 0;
     uint64_t total_empty_gc_pages = 0;
     uint64_t total_live_bytes = 0; //doesnt include canary or metadata size
+
+    int collection_times_index = 0;
+    double collection_times[MAX_COLLECTION_TIMES_INDEX]; //store in ms how much time each collection takes
 #endif
 
 #ifdef BSQ_GC_CHECK_ENABLED

--- a/src/runtime/memory/threadinfo.h
+++ b/src/runtime/memory/threadinfo.h
@@ -111,6 +111,26 @@ struct BSQMemoryTheadLocalInfo
         }
     }
 
+#ifdef MEM_STATS
+    double compute_average_collection_time() noexcept
+    {
+        double total_collection_time = 0;
+        int num_collections = 0;
+        for(int i = 0; i < MAX_COLLECTION_TIMES_INDEX; i++) {
+            double elapsed_time = collection_times[i];
+    
+            if(elapsed_time > 0.0) {
+                num_collections++;
+                total_collection_time += elapsed_time;
+            }
+        }
+    
+        return (total_collection_time / num_collections);
+    }
+#else
+    inline void compute_average_collection_time() = { };
+#endif
+
     void loadNativeRootSet() noexcept;
     void unloadNativeRootSet() noexcept;
 };

--- a/test/multiple_tree_deep.cpp
+++ b/test/multiple_tree_deep.cpp
@@ -1,0 +1,148 @@
+#include "../src/runtime/memory/gc.h"
+#include "../src/runtime/memory/threadinfo.h"
+
+#include <string>
+#include <format>
+#include <stack>
+#include <iostream>
+
+//had to add extra slot to represent val field
+struct TypeInfoBase TreeNodeType = {
+    .type_id = 1,
+    .type_size = 24,
+    .slot_size = 3,
+    .ptr_mask = "110",  
+    .typekey = "TreeNodeType"
+};
+
+struct TreeNodeValue {
+    TreeNodeValue* left;
+    TreeNodeValue* right;
+    int64_t val;
+};
+
+GCAllocator alloc3(24, REAL_ENTRY_SIZE(24), collect);
+
+//
+//Made this non-recursive to avoid tons of stack frames when we call
+//a collection
+//
+TreeNodeValue* makeTree(int64_t depth, int64_t val) {
+    if (depth < 0) {
+        return nullptr; 
+    }
+
+    std::stack<std::pair<TreeNodeValue*, int64_t>> stack;
+
+    TreeNodeValue* root = AllocType(TreeNodeValue, alloc3, &TreeNodeType);
+
+    root->left = nullptr;
+    root->right = nullptr;
+    root->val = val;
+
+    stack.push({root, depth});
+    while (!stack.empty()) {
+        auto [node, depth] = stack.top();
+        stack.pop();
+
+        if (depth > 0) {
+            //left child
+            node->left = AllocType(TreeNodeValue, alloc3, &TreeNodeType);
+            node->left->left = nullptr;
+            node->left->right = nullptr;
+            node->left->val = val;
+            stack.push({node->left, depth - 1});
+
+            //right child
+            node->right = AllocType(TreeNodeValue, alloc3, &TreeNodeType);
+            node->right->left = nullptr;
+            node->right->right = nullptr;
+            node->right->val = val;
+            stack.push({node->right, depth - 1});
+        }
+    }
+
+    return root;
+}
+
+std::string printtree(TreeNodeValue* node) {
+    if (node == nullptr) {
+        return "null"; 
+    }
+
+    std::string addr = "xx"; // Replace with std::format("{:x}", (uintptr_t)node) if available
+    std::string nodeStr = "[" + addr + ", " + std::to_string(node->val) + "]";
+
+    std::string leftStr = printtree(node->left);
+    std::string rightStr = printtree(node->right);
+
+    return nodeStr + ", " + leftStr + ", " + rightStr;
+}
+
+uint64_t find_size_bytes(TreeNodeValue* n) 
+{
+    if(n == nullptr) {
+        return 0;
+    }
+
+    return TreeNodeType.type_size + 
+           find_size_bytes(n->left) + 
+           find_size_bytes(n->right);
+}
+
+TreeNodeValue* garray[3] = {nullptr, nullptr, nullptr};
+
+//
+//Full tree of varrying depths
+//A possible improvement could be making tree for each depth up to a certain threshold (say n=14)
+//
+int main(int argc, char** argv) {
+    INIT_LOCKS();
+    GlobalDataStorage::g_global_data.initialize(sizeof(garray), (void**)garray);
+
+    InitBSQMemoryTheadLocalInfo();
+    gtl_info.disable_automatic_collections = true;
+    gtl_info.disable_stack_refs_for_tests = true;
+
+    GCAllocator* allocs[1] = { &alloc3 };
+    gtl_info.initializeGC<1>(allocs);
+
+    const int depth = 15;
+    const int iterations = 100;
+    int failed_iterations = 0;
+
+    std::cout << "Starting " << iterations << " iterations of GC stress testing for multiple_tree_deep...\n";
+
+    for (int i = 0; i < iterations; i++) {
+        TreeNodeValue* tree_root = makeTree(depth, 4);
+        garray[0] = tree_root;
+
+        uint64_t init_total_bytes = find_size_bytes(tree_root);
+
+        auto t1_start = printtree(tree_root);
+        collect();
+        
+        auto t1_end = printtree(tree_root);
+
+        assert(t1_start == t1_end);
+
+        uint64_t final = gtl_info.total_live_bytes;
+        assert(init_total_bytes == final);
+
+        gtl_info.disable_stack_refs_for_tests = true;
+        garray[0] = nullptr;
+
+        //Clear out pending decs
+        while(gtl_info.total_live_bytes != 0) {
+            collect();
+        }
+
+        assert(gtl_info.total_live_bytes == 0);
+    }
+    std::cout << "collection time " << gtl_info.compute_average_collection_time() << " ms\n";
+
+    std::cout << "Failed iterations: " << failed_iterations << "/" << iterations << "\n";
+    return failed_iterations > 0 ? 1 : 0;
+
+    return 0;
+}

--- a/test/multiple_tree_shared.cpp
+++ b/test/multiple_tree_shared.cpp
@@ -111,9 +111,16 @@ int main(int argc, char **argv)
     GCAllocator* allocs[2] = { &alloc2, &alloc4 };
     gtl_info.initializeGC<2>(allocs);
 
-    const int depth = 11;
+    const int depth = 10;
     const int iterations = 100;
     int failed_iterations = 0;
+
+    //
+    //If we want to have this run higher workloads (completly full collections)
+    //we need to do depth=11 then call multiple collections instead of just one to 
+    //properly clear our old tree. If we do not we collect further and further behind
+    //schedule (1024 filled pages) and the collector falls apart.
+    //
 
     std::cout << "Starting " << iterations << " iterations of GC stress testing for multiple_tree_shared...\n";
     auto test_start = std::chrono::high_resolution_clock::now();
@@ -132,9 +139,7 @@ int main(int argc, char **argv)
 
         // Drop root1 and collect
         garray[0] = nullptr;
-        for (int j = 0; j < 6; j++) {
-            collect();
-        }
+        collect();
 
         auto root2_final = printtree(root2);
 
@@ -155,14 +160,14 @@ int main(int argc, char **argv)
 
         // Drop everything and collect
         garray[1] = nullptr;
-        for (int j = 0; j < 6; j++) {
-            collect();
-        }
+        collect();
 
+        #if 0
         if (gtl_info.total_live_bytes != 0) {
             std::cerr << "Iteration " << i << " failed: memory not fully collected\n";
             failed_iterations++;
         }
+        #endif
     }
 
     //Didn't do these calculations in other tests but fun to see

--- a/test/multiple_tree_shared.cpp
+++ b/test/multiple_tree_shared.cpp
@@ -123,7 +123,6 @@ int main(int argc, char **argv)
     //
 
     std::cout << "Starting " << iterations << " iterations of GC stress testing for multiple_tree_shared...\n";
-    auto test_start = std::chrono::high_resolution_clock::now();
 
     for (int i = 0; i < iterations; i++) {
         // Create big tree and keep a subtree alive
@@ -139,6 +138,7 @@ int main(int argc, char **argv)
 
         // Drop root1 and collect
         garray[0] = nullptr;
+        //std::cout << "filled_pages_count " << gtl_info.newly_filled_pages_count << std::endl;
         collect();
 
         auto root2_final = printtree(root2);
@@ -170,12 +170,7 @@ int main(int argc, char **argv)
         #endif
     }
 
-    //Didn't do these calculations in other tests but fun to see
-    auto test_end = std::chrono::high_resolution_clock::now();
-    auto total_time_ms = std::chrono::duration_cast<std::chrono::milliseconds>(test_end - test_start).count();
-    double total_time_seconds = total_time_ms / 1000.0;
-
-    std::cout << "\nTest completed in " << std::fixed << std::setprecision(3) << total_time_seconds << " seconds\n";
+    std::cout << "collection time " << gtl_info.compute_average_collection_time() << " ms\n";
 
     std::cout << "Failed iterations: " << failed_iterations << "/" << iterations << "\n";
     return failed_iterations > 0 ? 1 : 0;

--- a/test/multiple_tree_shared.cpp
+++ b/test/multiple_tree_shared.cpp
@@ -92,6 +92,7 @@ uint64_t find_size_bytes(TreeNode3Value* n)
            find_size_bytes(n->n3);
 }
 
+
 void* garray[3] = {nullptr, nullptr, nullptr};
 
 //
@@ -136,16 +137,19 @@ int main(int argc, char **argv)
         auto root1_init = printtree(root1);
         auto root2_init = printtree(root2);
 
+        uint64_t subtree_size = find_size_bytes(root2->n1);
+        uint64_t expected_size = subtree_size + TreeNode1Type.type_size;
+
         // Drop root1 and collect
         garray[0] = nullptr;
-        //std::cout << "filled_pages_count " << gtl_info.newly_filled_pages_count << std::endl;
+
+        //Collect root1's tree
+        collect();
         collect();
 
         auto root2_final = printtree(root2);
 
         // Verify kept subtree is intact
-        uint64_t subtree_size = find_size_bytes(root2->n1);
-        uint64_t expected_size = subtree_size + TreeNode1Type.type_size;
         if (gtl_info.total_live_bytes != expected_size) {
             std::cerr << "Iteration " << i << " failed: incorrect live bytes\n";
             failed_iterations++;
@@ -162,12 +166,7 @@ int main(int argc, char **argv)
         garray[1] = nullptr;
         collect();
 
-        #if 0
-        if (gtl_info.total_live_bytes != 0) {
-            std::cerr << "Iteration " << i << " failed: memory not fully collected\n";
-            failed_iterations++;
-        }
-        #endif
+        assert(gtl_info.total_live_bytes == 0);
     }
 
     std::cout << "collection time " << gtl_info.compute_average_collection_time() << " ms\n";

--- a/test/multiple_tree_wide_drop_child.cpp
+++ b/test/multiple_tree_wide_drop_child.cpp
@@ -161,7 +161,6 @@ int main(int argc, char **argv)
     int failed_iterations = 0;
 
     std::cout << "Starting " << iterations << " iterations of GC stress testing for multiple_tree_wide_drop_child...\n";
-    auto test_start = std::chrono::high_resolution_clock::now();
 
     for (int i = 0; i < iterations; i++) {        
         TreeNodeValue* root = makeTree(depth, 2);
@@ -214,12 +213,7 @@ int main(int argc, char **argv)
         }
     }
 
-    //I may be having too much fun with these statistics
-    auto test_end = std::chrono::high_resolution_clock::now();
-    auto total_time_ms = std::chrono::duration_cast<std::chrono::milliseconds>(test_end - test_start).count();
-    double total_time_seconds = total_time_ms / 1000.0;
-
-    std::cout << "\nTest completed in " << std::fixed << std::setprecision(3) << total_time_seconds << " seconds\n";
+    std::cout << "collection time " << gtl_info.compute_average_collection_time() << " ms\n";
 
     std::cout << "Failed iterations: " << failed_iterations << "/" << iterations << "\n";
     return failed_iterations > 0 ? 1 : 0;

--- a/test/nbody.cpp
+++ b/test/nbody.cpp
@@ -311,15 +311,19 @@ int main(int argc, char** argv)
     
     printf("energy: %.9g\n", energy(sys));
 
-    //Lets collect every 10000 systems
+    //Collections are pretty fast for nbody since there
+    //is hardly any decrements happening, everything is just garbage
     for(int i = 0; i < n; i++) {
         sys = advance(sys, step);
-        if(i % 10000 == 0) {
+        int filled_count = gtl_info.newly_filled_pages_count;
+        if(filled_count >= BSQ_COLLECTION_THRESHOLD) {
             collect();
         }
     }
 
     printf("energy: %.9g\n", energy(sys));
+
+    std::cout << "collection time " << gtl_info.compute_average_collection_time() << " ms\n";
 
     return 0;
 }


### PR DESCRIPTION
- added necessary code to track in ms how long each collection cycle takes
- each collection cycle is stored in a global circular buffer
- added multiple_tree_deep test to test the speed of our gc for collecting trees close to the maximum size that would normally fill up maximum number of pages to trigger a collection
- current performance has been tracked in nbody, multiple_tree_deep, and multiple_tree_shared

### Heres some notes I took on performances
//NOTE: All collection times are averages over 100 iterations of each test
//each tree contains 2^16 nodes, we slightly exceed max filled pages count
//entire tree dies at once then we collect until alloc bytes == 0
multiple_tree_deep : avg ~21ms
  21.5343 ms
  20.4045 ms
  20.7846 ms
  22.2014 ms
  20.8469 ms

//each tree contains roughly 3^9 nodes
//may not be the best metric since we collect 2/3 of the tree
//then collect remaining 1/3. The final collection to clear subtree
//somewhat skews overall collection time
multiple_tree_shared : avg ~4.8ms
  5.21309 ms
  4.55781 ms
  4.64349 ms
  4.79157 ms
  4.75244 ms

//Fills most pages, most data is unmarked garbage
//Collection triggers when newly_filled_pages_count == BSQ_MAX_COLLECTION_THRESHOLD
nbody : avg ~0.7ms
  0.709316 ms
  0.726625 ms
  0.676232 ms
  0.795564 ms
  0.705309 ms