### PR TITLE
Hotspot Monitoring + Decrements Optimization

### DIFF
--- a/build/makefile
+++ b/build/makefile
@@ -22,9 +22,8 @@ CC=g++
 CSTDFLAGS=-Wall -Wextra -Wno-unused-parameter -Wuninitialized -Werror -std=gnu++20 -fno-exceptions -fno-rtti -fno-strict-aliasing -fno-omit-frame-pointer -fno-stack-protector
 
 CFLAGS_OPT.dev=-O0 -g -ggdb 
-CFLAGS_OPT.release=-O3 -march=x86-64-v3
+CFLAGS_OPT.release=-O2 -march=x86-64-v3
 CFLAGS=${CFLAGS_OPT.${BUILD}} ${CSTDFLAGS}
-CFLAGS_TEST=${CFLAGS_OPT.dev} ${CSTDFLAGS}
 
 SUPPORT_HEADERS=$(RUNTIME_DIR)common.h $(SUPPORT_DIR)xalloc.h $(SUPPORT_DIR)arraylist.h $(SUPPORT_DIR)pagetable.h $(SUPPORT_DIR)qsort.h 
 SUPPORT_SOURCES=$(RUNTIME_DIR)common.cpp $(SUPPORT_DIR)xalloc.cpp
@@ -42,7 +41,7 @@ test: $(SUPPORT_HEADERS) $(MEMORY_HEADERS) $(SUPPORT_OBJS) $(MEMORY_OBJS)
 		exit 1; \
 	fi
 	@mkdir -p $(OUT_EXE)
-	$(CC) $(CFLAGS_TEST) -o $(OUT_EXE)$(TEST) $(SUPPORT_OBJS) $(MEMORY_OBJS) $(TEST_DIR)$(TEST).cpp
+	$(CC) $(CFLAGS) -o $(OUT_EXE)$(TEST) $(SUPPORT_OBJS) $(MEMORY_OBJS) $(TEST_DIR)$(TEST).cpp
 	@echo "Running test: $(TEST)"
 	@$(OUT_EXE)$(TEST)
 

--- a/src/runtime/memory/allocator.cpp
+++ b/src/runtime/memory/allocator.cpp
@@ -14,7 +14,7 @@ PageInfo* PageInfo::initialize(void* block, uint16_t allocsize, uint16_t realsiz
     pp->allocsize = allocsize;
     pp->realsize = realsize;
     pp->pending_decs_count = 0;
-    pp->approx_utilization = 100.0f; //approx util has not been calculated
+    pp->approx_utilization = 100.0f; // Approx util has not been calculated
     pp->left = nullptr;
     pp->right = nullptr;
     pp->entrycount = (BSQ_BLOCK_ALLOCATION_SIZE - (pp->data - (uint8_t*)pp)) / realsize;
@@ -38,7 +38,7 @@ void PageInfo::rebuild() noexcept
         MetaData* meta = this->getMetaEntryAtIndex(i);
         
         if(GC_SHOULD_FREE_LIST_ADD(meta)) {
-            //just to be safe reset metadata
+            // Just to be safe reset metadata
             RESET_METADATA_FOR_OBJECT(meta, MAX_FWD_INDEX);
             FreeListEntry* entry = this->getFreelistEntryAtIndex(i);
             entry->next = this->freelist;
@@ -106,9 +106,9 @@ void GCAllocator::processPage(PageInfo* p) noexcept
         GET_BUCKET_INDEX(n_util, NUM_HIGH_UTIL_BUCKETS, bucket_index, 1);
         this->insertPageInBucket(&this->high_utilization_buckets[bucket_index], p, n_util);
     }
-    //if our page freshly became full we need to gc
+    // If our page freshly became full we need to gc
     else if(IS_FULL(n_util) && !IS_FULL(old_util)) {
-        //We dont want to collect evac page
+        // We dont want to collect evac page
         if(!(p == this->evac_page)) {
             p->next = this->pendinggc_pages;
             pendinggc_pages = p;
@@ -118,7 +118,7 @@ void GCAllocator::processPage(PageInfo* p) noexcept
             filled_pages = p;
         }
     }
-    //if our page was full before and still full put on filled pages
+    // If our page was full before and still full put on filled pages
     else if(IS_FULL(n_util) && IS_FULL(old_util)) {
         p->next = this->filled_pages;
         filled_pages = p;
@@ -161,21 +161,20 @@ void GCAllocator::allocatorRefreshPage() noexcept
         this->alloc_page = this->getFreshPageForAllocator();
     }
     else {
-        //rotate collection pages
+        // Rotate collection pages
         processPage(this->alloc_page);
         this->alloc_page = nullptr;
 
-        //use BSQ_COLLECTION_THRESHOLD; NOTE ONLY INCREMENT when we have a full page
+        //use BSQ_COLLECTION_THRESHOLD; NOTE: ONLY INCREMENT when we have a full page
         gtl_info.newly_filled_pages_count++;
 
-        //check if we need to collect and do so
+        // If we exceed our filled pages thresh collect
         if(gtl_info.newly_filled_pages_count == BSQ_COLLECTION_THRESHOLD) {
             if(!gtl_info.disable_automatic_collections) {
                 collect();
             }
         }
     
-        //get the new page
         this->alloc_page = this->getFreshPageForAllocator();
     }
 
@@ -213,12 +212,12 @@ void GCAllocator::updateMemStats()
         filled_it = filled_it->next;
     }
 
-    //compute stats for high util pages
+    // Compute stats for high util pages
     for(int i = 0; i < NUM_HIGH_UTIL_BUCKETS; i++) {
         traverseBST(this->high_utilization_buckets[i]);
     }
 
-    //compute stats for low util pages
+    // Compute stats for low util pages
     for(int i = 0; i < NUM_LOW_UTIL_BUCKETS; i++) {
         traverseBST(this->low_utilization_buckets[i]);
     }

--- a/src/runtime/memory/allocator.cpp
+++ b/src/runtime/memory/allocator.cpp
@@ -13,6 +13,7 @@ PageInfo* PageInfo::initialize(void* block, uint16_t allocsize, uint16_t realsiz
     pp->data = ((uint8_t*)block + sizeof(PageInfo));
     pp->allocsize = allocsize;
     pp->realsize = realsize;
+    pp->pending_decs_count = 0;
     pp->approx_utilization = 100.0f; //approx util has not been calculated
     pp->left = nullptr;
     pp->right = nullptr;

--- a/src/runtime/memory/allocator.h
+++ b/src/runtime/memory/allocator.h
@@ -244,9 +244,8 @@ private:
     
         PageInfo* current = root;
         while (current != nullptr) {
-            //if current and our pages utilization are equal we add it to this pages list
-            //a possible enhancement could be inserting at beginning of list, would mean
-            //having to refactor this code though
+            // If current and our pages utilization are equal we add it to this pages list
+            // TODO: Insert at beginning of list, means we need a reference from parent node
             if(UTILIZATIONS_ARE_EQUAL(n_util, root->approx_utilization)) {
                 if(current->next == nullptr) {
                     current->next = new_page;
@@ -261,10 +260,10 @@ private:
                 break;
             }
 
-            //traverse down left subtree
+            // Traverse down left subtree
             else if (n_util < current->approx_utilization) {
                 if (current->left == nullptr) {
-                    //Insert as the left child
+                    // Insert as the left child
                     current->left = new_page;
                     break;
                 } else {
@@ -272,10 +271,10 @@ private:
                 }
             } 
 
-            //traverse down right subtree
+            // Traverse down right subtree
             else {
                 if (current->right == nullptr) {
-                    //Insert as the right child
+                    // Insert as the right child
                     current->right = new_page;
                     break;
                 } else {
@@ -312,7 +311,7 @@ private:
                     else {
                         PageInfo* successor = getSuccessor(root);
 
-                        //crucial to update sucessors ptrs
+                        // Crucial to update sucessors ptrs
                         successor->left = root->left;
                         successor->right = root->right;
                         successor->next = root->next;
@@ -367,14 +366,14 @@ private:
                 cur = cur->left;
             }
             
-            if(cur == buckets[i]) { //If cur is root
+            if(cur == buckets[i]) { // If cur is root
                 if(cur->next != nullptr) {
                     buckets[i] = cur->next;
                     buckets[i]->left = cur->left;
                     buckets[i]->right = cur->right;
                 } 
                 else {
-                    //Normal BST removal
+                    // Normal BST removal
                     if(cur->right != nullptr) {
                         buckets[i] = cur->right;
                     } 
@@ -383,7 +382,7 @@ private:
                     }
                 }
             } 
-            else { //If cur is not root
+            else { // If cur is not root
                 if(cur->right != nullptr) {
                     parent->left = cur->right;
                 }
@@ -399,7 +398,6 @@ private:
 
     PageInfo* getFreshPageForAllocator() noexcept
     {
-        //find lowest util bucket with stuff, get lowest util page from bucket
         PageInfo* page = findLowestUtilPage(low_utilization_buckets, NUM_LOW_UTIL_BUCKETS);
         if(page == nullptr) {
             page = GlobalPageGCManager::g_gc_page_manager.allocateFreshPage(this->allocsize, this->realsize);
@@ -410,7 +408,6 @@ private:
 
     PageInfo* getFreshPageForEvacuation() noexcept
     {
-        //Try to grab high util, if fails go to low, fall thoguh making fresh page
         PageInfo* page = findLowestUtilPage(high_utilization_buckets, NUM_HIGH_UTIL_BUCKETS);
         if(page == nullptr) {
             page = findLowestUtilPage(low_utilization_buckets, NUM_LOW_UTIL_BUCKETS);
@@ -424,7 +421,7 @@ private:
 
     void allocatorRefreshEvacuationPage() noexcept
     {
-        //if our evac page is full put it on filled pages list
+        // If our evac page is full put directly on filled pages list
         if(this->evac_page != nullptr && this->evac_page->freecount == 0) {
             this->evac_page->approx_utilization = 1.0f;
             this->evac_page->next = this->filled_pages;
@@ -443,7 +440,7 @@ public:
         return this->allocsize;
     }
 
-    //Simple check to see if a page is in alloc/evac/pendinggc pages
+    // Simple check to see if a page is in alloc/evac/pendinggc pages
     bool checkNonAllocOrGCPage(PageInfo* p) {
         if(p == alloc_page || p == evac_page) {
             return false;
@@ -460,7 +457,7 @@ public:
         return true;
     }
 
-    //Used in case where a page's utilization changed and it isnt being grabbed for evac/alloc
+    // Used in case where a page's utilization changed and it isnt being grabbed for evac/alloc
     void deleteOldPage(PageInfo* p) 
     {
         int bucket_index = 0;
@@ -477,7 +474,7 @@ public:
                 &this->high_utilization_buckets[bucket_index], p);
         }
 
-        //May want to make this traversal not O(n) worst case (sort?)
+        // May want to make this traversal not O(n) worst case (sort?)
         else {
             PageInfo* cur = this->filled_pages;
             PageInfo* prev = nullptr;

--- a/src/runtime/memory/allocator.h
+++ b/src/runtime/memory/allocator.h
@@ -76,6 +76,7 @@ public:
     uint16_t freecount;
 
     float approx_utilization;
+    uint16_t pending_decs_count;
 
     static PageInfo* initialize(void* block, uint16_t allocsize, uint16_t realsize) noexcept;
 

--- a/src/runtime/memory/threadinfo.h
+++ b/src/runtime/memory/threadinfo.h
@@ -74,8 +74,9 @@ struct BSQMemoryTheadLocalInfo
     ArrayList<void*> pending_young; //the list of young objects that need to be processed
     ArrayList<void*> pending_decs; //the list of objects that need to be decremented 
 
-    int processing_stack_it = 0;
-    PageInfo* processing_stack[BSQ_INITIAL_MAX_DECREMENT_COUNT];
+    //TODO: Once PID is implemented this will need to use this->max_decrement_count
+    int decremented_pages_index = 0;
+    PageInfo* decremented_pages[BSQ_INITIAL_MAX_DECREMENT_COUNT];
 
     size_t max_decrement_count;
 

--- a/test/multiple_tree_deep.cpp
+++ b/test/multiple_tree_deep.cpp
@@ -129,7 +129,6 @@ int main(int argc, char** argv) {
         uint64_t final = gtl_info.total_live_bytes;
         assert(init_total_bytes == final);
 
-        gtl_info.disable_stack_refs_for_tests = true;
         garray[0] = nullptr;
 
         //Clear out pending decs
@@ -137,9 +136,16 @@ int main(int argc, char** argv) {
             collect();
         }
 
-        assert(gtl_info.total_live_bytes == 0);
+        if(gtl_info.total_live_bytes != 0) {
+            std::cerr << "Iteration " << i << " failed: incorrect live bytes\n";
+            failed_iterations++;
+            continue;
+        }
     }
-    std::cout << "collection time " << gtl_info.compute_average_collection_time() << " ms\n";
+    std::cout << "collection time " << gtl_info.compute_average_time(gtl_info.collection_times) << " ms\n";
+    std::cout << "marking time " << gtl_info.compute_average_time(gtl_info.marking_times) << " ms\n";
+    std::cout << "evacuation time " << gtl_info.compute_average_time(gtl_info.evacuation_times) << " ms\n";
+    std::cout << "decrement time " << gtl_info.compute_average_time(gtl_info.decrement_times) << " ms\n";
 
     std::cout << "Failed iterations: " << failed_iterations << "/" << iterations << "\n";
     return failed_iterations > 0 ? 1 : 0;

--- a/test/multiple_tree_shared.cpp
+++ b/test/multiple_tree_shared.cpp
@@ -112,7 +112,7 @@ int main(int argc, char **argv)
     GCAllocator* allocs[2] = { &alloc2, &alloc4 };
     gtl_info.initializeGC<2>(allocs);
 
-    const int depth = 10;
+    const int depth = 9;
     const int iterations = 100;
     int failed_iterations = 0;
 
@@ -140,10 +140,13 @@ int main(int argc, char **argv)
         uint64_t subtree_size = find_size_bytes(root2->n1);
         uint64_t expected_size = subtree_size + TreeNode1Type.type_size;
 
+        collect();
+
         // Drop root1 and collect
         garray[0] = nullptr;
 
         //Collect root1's tree
+        collect();
         collect();
         collect();
 
@@ -169,7 +172,10 @@ int main(int argc, char **argv)
         assert(gtl_info.total_live_bytes == 0);
     }
 
-    std::cout << "collection time " << gtl_info.compute_average_collection_time() << " ms\n";
+    std::cout << "collection time " << gtl_info.compute_average_time(gtl_info.collection_times) << " ms\n";
+    std::cout << "marking time " << gtl_info.compute_average_time(gtl_info.marking_times) << " ms\n";
+    std::cout << "evacuation time " << gtl_info.compute_average_time(gtl_info.evacuation_times) << " ms\n";
+    std::cout << "decrement time " << gtl_info.compute_average_time(gtl_info.decrement_times) << " ms\n";
 
     std::cout << "Failed iterations: " << failed_iterations << "/" << iterations << "\n";
     return failed_iterations > 0 ? 1 : 0;

--- a/test/multiple_tree_shared.cpp
+++ b/test/multiple_tree_shared.cpp
@@ -146,9 +146,9 @@ int main(int argc, char **argv)
         garray[0] = nullptr;
 
         //Collect root1's tree
-        collect();
-        collect();
-        collect();
+        while(gtl_info.total_live_bytes > expected_size) {
+            collect();
+        }
 
         auto root2_final = printtree(root2);
 

--- a/test/multiple_tree_wide_drop_child.cpp
+++ b/test/multiple_tree_wide_drop_child.cpp
@@ -213,8 +213,11 @@ int main(int argc, char **argv)
         }
     }
 
-    std::cout << "collection time " << gtl_info.compute_average_collection_time() << " ms\n";
-
+    std::cout << "collection time " << gtl_info.compute_average_time(gtl_info.collection_times) << " ms\n";
+    std::cout << "marking time " << gtl_info.compute_average_time(gtl_info.marking_times) << " ms\n";
+    std::cout << "evacuation time " << gtl_info.compute_average_time(gtl_info.evacuation_times) << " ms\n";
+    std::cout << "decrement time " << gtl_info.compute_average_time(gtl_info.decrement_times) << " ms\n";
     std::cout << "Failed iterations: " << failed_iterations << "/" << iterations << "\n";
+    
     return failed_iterations > 0 ? 1 : 0;
 }

--- a/test/nbody.cpp
+++ b/test/nbody.cpp
@@ -323,7 +323,9 @@ int main(int argc, char** argv)
 
     printf("energy: %.9g\n", energy(sys));
 
-    std::cout << "collection time " << gtl_info.compute_average_collection_time() << " ms\n";
-
+    std::cout << "collection time " << gtl_info.compute_average_time(gtl_info.collection_times) << " ms\n";
+    std::cout << "marking time " << gtl_info.compute_average_time(gtl_info.marking_times) << " ms\n";
+    std::cout << "evacuation time " << gtl_info.compute_average_time(gtl_info.evacuation_times) << " ms\n";
+    std::cout << "decrement time " << gtl_info.compute_average_time(gtl_info.decrement_times) << " ms\n";
     return 0;
 }

--- a/test/tree_basic.cpp
+++ b/test/tree_basic.cpp
@@ -61,6 +61,7 @@ int main(int argc, char** argv) {
 
     InitBSQMemoryTheadLocalInfo();
     gtl_info.disable_automatic_collections = true;
+    gtl_info.disable_stack_refs_for_tests = true;
 
     GCAllocator* allocs[1] = { &alloc3 };
     gtl_info.initializeGC<1>(allocs);


### PR DESCRIPTION
 - Added code to monitor speed of common hotspots (marking, evacuation, decrements)
 - Delayed page moving in processing decrements to avoid unnecessary bst operations, this produced ~400% performance improvement on trees with large amounts of nodes and lots of work to handle in one collection cycle (~22ms for multiple_tree_deep before, and now ~4.5ms)
 - To achieve this each page stores a count of how many pending decrements are yet to process (2 byte number)
 - Cleaned up some old comments